### PR TITLE
fix(chart): reset K-line price scale on symbol switch (#6)

### DIFF
--- a/src/components/candle-chart.css.ts
+++ b/src/components/candle-chart.css.ts
@@ -43,6 +43,16 @@ export const tfBtn = styleVariants({
     ],
 });
 
+export const iconBtn = style([
+    tfBase,
+    {
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '2px 6px',
+    },
+]);
+
 export const toolbarDivider = style({
     width: '1px',
     alignSelf: 'stretch',

--- a/src/components/candle-chart.tsx
+++ b/src/components/candle-chart.tsx
@@ -12,7 +12,7 @@ import {
     type ISeriesApi,
     type UTCTimestamp,
 } from 'lightweight-charts';
-import { Bell, Crosshair, OctagonX, X } from 'lucide-react';
+import { Bell, Crosshair, Maximize2, OctagonX, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuote } from '../hooks/use-stream';
 import { bollinger, ema, sma, vwap } from '../lib/indicators';
@@ -388,6 +388,13 @@ export function CandleChart({
                 loadedKeyRef.current = loadKey;
                 setDataVersion((v) => v + 1);
                 chartRef.current?.timeScale().scrollToRealTime();
+                // a manual price-axis drag disables autoScale and pins the
+                // range; without re-enabling it the prior symbol's price band
+                // sticks (e.g. a 1000元 stock leaves a 10元 stock off-screen,
+                // issue #6) — restore auto-fit for every freshly loaded symbol
+                candleSeriesRef.current
+                    .priceScale()
+                    .applyOptions({ autoScale: true });
             })
             .catch(() => {
                 if (cancelled) return;
@@ -522,6 +529,15 @@ export function CandleChart({
             );
             return next;
         });
+    };
+
+    // recalibrate the view — re-fit both axes after the user has panned or
+    // dragged the price scale into a corner (issue #6: no reset control)
+    const resetView = () => {
+        const chart = chartRef.current;
+        if (!chart) return;
+        candleSeriesRef.current?.priceScale().applyOptions({ autoScale: true });
+        chart.timeScale().fitContent();
     };
 
     // draw working-order price lines (buy=up color / sell=down color)
@@ -711,6 +727,14 @@ export function CandleChart({
                         {t.label}
                     </button>
                 ))}
+                <button
+                    className={styles.iconBtn}
+                    onClick={resetView}
+                    title='重設視圖（自動縮放）'
+                    aria-label='重設視圖'
+                >
+                    <Maximize2 size={12} />
+                </button>
                 <span className={styles.toolbarDivider} />
                 {TRADE_MODES.map((m) => (
                     <button


### PR DESCRIPTION
## Summary
- **Bug**: dragging the K-line price (vertical) axis disables lightweight-charts' `autoScale` and pins the range. `CandleChart` reuses one chart instance across symbol changes, so the prior symbol's price band carried over — switching from a 千元股 to a 十元股 left the candles off-screen with no recovery control (issue #6).
- **Fix 1**: re-enable `autoScale` on the candle price scale every time a new symbol's history loads (`candle-chart.tsx`, in the kbars load effect), so each symbol auto-fits its own range.
- **Fix 2**: add a **重設視圖** toolbar button (lucide `Maximize2`) that re-fits both axes on demand — the missing 校正按鈕. Users can still drag to rescale; the next manual drag re-disables autoscale as before.

Closes #6

## Test plan
- [x] `npm run build` (tsc -b + vite build) passes clean
- [ ] Manual: select 千元股 → drag price axis → select 十元股 → candles auto-fit into view
- [ ] Manual: pan/zoom away → click 重設視圖 → both axes re-fit
