### PR TITLE
feat(workspace): 自訂網頁面板 — iframe 內嵌任意 http(s) 頁面進版面

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import { ScannerPanel } from './components/scanner-panel';
 import { TickTape } from './components/tick-tape';
 import { TrayPanel } from './components/tray-panel';
 import { Watchlist } from './components/watchlist';
+import { WebviewPanel } from './components/webview-panel';
 import * as panel from './components/panel.css';
 import { useHotkeys } from './hooks/use-hotkeys';
 import { usePoll } from './hooks/use-poll';
@@ -124,6 +125,7 @@ function BlockBody({
     dockProps,
     onSelectCode,
     refreshTrading,
+    onBlockUrlChange,
 }: {
     block: Block;
     contract: ContractInfo | null;
@@ -132,6 +134,7 @@ function BlockBody({
     dockProps: React.ComponentProps<typeof BottomDock>;
     onSelectCode: (code: string) => void;
     refreshTrading: () => void;
+    onBlockUrlChange: (id: string, url: string | null) => void;
 }) {
     switch (block.type) {
         case 'watchlist':
@@ -248,6 +251,13 @@ function BlockBody({
             ) : (
                 <BlockPlaceholder />
             );
+        case 'webview':
+            return (
+                <WebviewPanel
+                    url={block.url ?? null}
+                    onUrlChange={(url) => onBlockUrlChange(block.id, url)}
+                />
+            );
     }
 }
 
@@ -260,6 +270,7 @@ interface BlockViewProps {
     selected: ContractInfo | null;
     onPinChange: (id: string, pin: string | null) => void;
     onRemove: (id: string) => void;
+    onBlockUrlChange: (id: string, url: string | null) => void;
     snapshot?: import('./lib/types/market').Snapshot;
     watchlistProps: React.ComponentProps<typeof Watchlist>;
     dockProps: React.ComponentProps<typeof BottomDock>;
@@ -639,6 +650,18 @@ export default function App() {
         [workspace, updateWorkspace],
     );
 
+    const setBlockUrl = useCallback(
+        (id: string, url: string | null) => {
+            updateWorkspace({
+                ...workspace,
+                blocks: workspace.blocks.map((b) =>
+                    b.id === id ? { ...b, url: url ?? undefined } : b,
+                ),
+            });
+        },
+        [workspace, updateWorkspace],
+    );
+
     const resetWorkspace = useCallback(() => {
         updateWorkspace(structuredClone(DEFAULT_WORKSPACE));
     }, [updateWorkspace]);
@@ -826,6 +849,7 @@ export default function App() {
                                     selected={selected}
                                     onPinChange={setBlockPin}
                                     onRemove={removeBlock}
+                                    onBlockUrlChange={setBlockUrl}
                                     snapshot={
                                         block.pin
                                             ? undefined

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -255,6 +255,7 @@ function BlockBody({
             return (
                 <WebviewPanel
                     url={block.url ?? null}
+                    code={contract?.code ?? null}
                     onUrlChange={(url) => onBlockUrlChange(block.id, url)}
                 />
             );

--- a/src/components/webview-panel.css.ts
+++ b/src/components/webview-panel.css.ts
@@ -1,0 +1,89 @@
+// src/components/webview-panel.css.ts
+
+import { style } from '@vanilla-extract/css';
+import { vars } from '../theme.css';
+
+export const wrap = style({
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
+    height: '100%',
+});
+
+export const toolbar = style({
+    display: 'flex',
+    alignItems: 'center',
+    gap: vars.space.xs,
+    padding: `4px ${vars.space.sm}`,
+    borderBottom: `1px solid ${vars.color.border}`,
+    flexShrink: 0,
+});
+
+export const urlText = style({
+    flex: 1,
+    minWidth: 0,
+    fontFamily: vars.font.body,
+    fontSize: '0.66rem',
+    color: vars.color.mutedForeground,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+});
+
+export const btn = style({
+    fontFamily: vars.font.body,
+    fontSize: '0.64rem',
+    color: vars.color.mutedForeground,
+    background: 'transparent',
+    border: `1px solid ${vars.color.border}`,
+    borderRadius: vars.radius.sm,
+    padding: '2px 10px',
+    cursor: 'pointer',
+    flexShrink: 0,
+    ':hover': { color: vars.color.foreground },
+});
+
+export const frame = style({
+    flex: 1,
+    width: '100%',
+    border: 0,
+    // 面板底色跟著主題走；頁面載入前不要閃白
+    background: 'transparent',
+});
+
+export const setup = style({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: vars.space.sm,
+    height: '100%',
+    padding: vars.space.md,
+});
+
+export const setupRow = style({
+    display: 'flex',
+    gap: vars.space.xs,
+});
+
+export const input = style({
+    fontFamily: vars.font.body,
+    fontSize: '0.72rem',
+    color: vars.color.foreground,
+    background: 'transparent',
+    border: `1px solid ${vars.color.border}`,
+    borderRadius: vars.radius.sm,
+    padding: '6px 10px',
+    width: '100%',
+    maxWidth: 420,
+    ':focus': { outline: 'none', borderColor: vars.color.accent },
+});
+
+export const hint = style({
+    fontFamily: vars.font.body,
+    fontSize: '0.62rem',
+    color: vars.color.mutedForeground,
+    textAlign: 'center',
+    maxWidth: 420,
+    lineHeight: 1.5,
+});

--- a/src/components/webview-panel.tsx
+++ b/src/components/webview-panel.tsx
@@ -2,6 +2,8 @@
 //
 // 用例：自架 dashboard／內網監控頁／TradingView 等外部工具，跟行情面板同一個版面。
 // URL 存在 Block.url（隨 workspace/版面 profile 一起持久化）。
+// 連動：URL 含 {code} 佔位符 → 代入面板目前商品代碼（跟隨全域選股或釘選），
+// 選股切換時 iframe 以新網址重載；靜態 URL 不受影響。
 // 安全：僅接受 http/https；iframe 帶 sandbox（不給 top-navigation）。目標站若以
 // X-Frame-Options / CSP frame-ancestors 拒絕內嵌，瀏覽器會擋下——面板顯示空白屬預期。
 
@@ -23,11 +25,22 @@ function normalizeUrl(raw: string): string | null {
     }
 }
 
+// {code} 在 URL path 段會被 URL 序列化成 %7Bcode%7D（query 段保持原樣），兩種都代換。
+function isTemplate(url: string): boolean {
+    return url.includes('{code}') || url.includes('%7Bcode%7D');
+}
+
+function fillTemplate(url: string, code: string): string {
+    return url.replaceAll('{code}', code).replaceAll('%7Bcode%7D', code);
+}
+
 export function WebviewPanel({
     url,
+    code,
     onUrlChange,
 }: {
     url: string | null;
+    code: string | null;
     onUrlChange: (url: string | null) => void;
 }) {
     const [editing, setEditing] = useState(url == null);
@@ -72,18 +85,39 @@ export function WebviewPanel({
                     ) : null}
                 </div>
                 <p className={css.hint}>
-                    僅支援 http/https。目標網站若禁止內嵌（X-Frame-Options /
-                    frame-ancestors）將無法顯示。
+                    僅支援 http/https。URL 含 {'{code}'}{' '}
+                    會代入目前商品代碼並跟著選股連動。目標網站若禁止內嵌
+                    （X-Frame-Options / frame-ancestors）將無法顯示。
                 </p>
             </div>
         );
     }
 
+    if (isTemplate(url) && !code) {
+        return (
+            <div className={css.setup}>
+                <p className={css.hint}>
+                    等待商品…（URL 含 {'{code}'}，選擇商品後載入）
+                </p>
+                <button
+                    className={css.btn}
+                    onClick={() => {
+                        setDraft(url);
+                        setEditing(true);
+                    }}
+                >
+                    變更
+                </button>
+            </div>
+        );
+    }
+    const src = code ? fillTemplate(url, code) : url;
+
     return (
         <div className={css.wrap}>
             <div className={css.toolbar}>
-                <span className={css.urlText} title={url}>
-                    {url}
+                <span className={css.urlText} title={src}>
+                    {src}
                 </span>
                 <button
                     className={css.btn}
@@ -102,9 +136,9 @@ export function WebviewPanel({
                 </button>
             </div>
             <iframe
-                key={reloadKey}
+                key={`${reloadKey}:${src}`}
                 className={css.frame}
-                src={url}
+                src={src}
                 title='自訂網頁'
                 sandbox='allow-scripts allow-same-origin allow-forms allow-popups'
                 referrerPolicy='no-referrer'

--- a/src/components/webview-panel.tsx
+++ b/src/components/webview-panel.tsx
@@ -1,0 +1,114 @@
+// src/components/webview-panel.tsx — 自訂網頁面板：把任意 http(s) 頁面嵌進 workspace
+//
+// 用例：自架 dashboard／內網監控頁／TradingView 等外部工具，跟行情面板同一個版面。
+// URL 存在 Block.url（隨 workspace/版面 profile 一起持久化）。
+// 安全：僅接受 http/https；iframe 帶 sandbox（不給 top-navigation）。目標站若以
+// X-Frame-Options / CSP frame-ancestors 拒絕內嵌，瀏覽器會擋下——面板顯示空白屬預期。
+
+import { useState } from 'react';
+import * as css from './webview-panel.css';
+
+function normalizeUrl(raw: string): string | null {
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    const candidate = /^https?:\/\//i.test(trimmed)
+        ? trimmed
+        : `http://${trimmed}`;
+    try {
+        const u = new URL(candidate);
+        if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
+        return u.href;
+    } catch {
+        return null;
+    }
+}
+
+export function WebviewPanel({
+    url,
+    onUrlChange,
+}: {
+    url: string | null;
+    onUrlChange: (url: string | null) => void;
+}) {
+    const [editing, setEditing] = useState(url == null);
+    const [draft, setDraft] = useState(url ?? '');
+    const [reloadKey, setReloadKey] = useState(0);
+
+    const submit = () => {
+        const next = normalizeUrl(draft);
+        if (!next) return;
+        onUrlChange(next);
+        setDraft(next);
+        setEditing(false);
+    };
+
+    if (editing || !url) {
+        return (
+            <div className={css.setup}>
+                <input
+                    className={css.input}
+                    value={draft}
+                    placeholder='http://127.0.0.1:8787 或任何網址'
+                    onChange={(e) => setDraft(e.target.value)}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') submit();
+                    }}
+                    autoFocus
+                />
+                <div className={css.setupRow}>
+                    <button className={css.btn} onClick={submit}>
+                        載入
+                    </button>
+                    {url ? (
+                        <button
+                            className={css.btn}
+                            onClick={() => {
+                                setDraft(url);
+                                setEditing(false);
+                            }}
+                        >
+                            取消
+                        </button>
+                    ) : null}
+                </div>
+                <p className={css.hint}>
+                    僅支援 http/https。目標網站若禁止內嵌（X-Frame-Options /
+                    frame-ancestors）將無法顯示。
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <div className={css.wrap}>
+            <div className={css.toolbar}>
+                <span className={css.urlText} title={url}>
+                    {url}
+                </span>
+                <button
+                    className={css.btn}
+                    onClick={() => setReloadKey((k) => k + 1)}
+                >
+                    重整
+                </button>
+                <button
+                    className={css.btn}
+                    onClick={() => {
+                        setDraft(url);
+                        setEditing(true);
+                    }}
+                >
+                    變更
+                </button>
+            </div>
+            <iframe
+                key={reloadKey}
+                className={css.frame}
+                src={url}
+                title='自訂網頁'
+                sandbox='allow-scripts allow-same-origin allow-forms allow-popups'
+                referrerPolicy='no-referrer'
+            />
+        </div>
+    );
+}

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -189,7 +189,8 @@ export const BLOCK_META: Record<
     },
     webview: {
         label: '自訂網頁',
-        pinnable: false,
+        // pinnable：URL 含 {code} 時代入商品代碼（跟隨選股或釘選）；靜態 URL 不受影響
+        pinnable: true,
         singleton: false,
         defaultSize: { w: 8, h: 10, minW: 3, minH: 4 },
     },

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -24,13 +24,16 @@ export type BlockType =
     | 'heatmap'
     | 'optpnl'
     | 'backtest'
-    | 'assistant';
+    | 'assistant'
+    | 'webview';
 
 export interface Block {
     id: string;
     type: BlockType;
     // null → follows the globally selected symbol; string → pinned to a code
     pin: string | null;
+    // webview only: the embedded page URL (persisted with the workspace)
+    url?: string;
 }
 
 export interface Workspace {
@@ -183,6 +186,12 @@ export const BLOCK_META: Record<
         pinnable: false,
         singleton: true,
         defaultSize: { w: 7, h: 14, minW: 5, minH: 9 },
+    },
+    webview: {
+        label: '自訂網頁',
+        pinnable: false,
+        singleton: false,
+        defaultSize: { w: 8, h: 10, minW: 3, minH: 4 },
     },
 };
 


### PR DESCRIPTION
## 動機

很多交易者有自架的輔助頁面（自建 dashboard、內網監控、TradingView 等），目前只能開瀏覽器另一個視窗看。這個 PR 新增一個通用的「自訂網頁」面板，把任意 http(s) 頁面 iframe 進 workspace，跟行情/下單面板同一個版面拖拉排版、隨版面 profile 儲存。

**TL;DR (EN):** adds a generic `webview` block type that embeds any http(s) page via a sandboxed iframe, so users can dock self-hosted dashboards / external tools inside the workspace grid.

## 設計

- 新 `BlockType: 'webview'`，非 singleton（可開多個、各嵌不同頁面）。
- URL 存在 `Block.url`（optional 欄位，向後相容既有 localStorage workspace / profiles），未設定時面板內顯示輸入框；設定後工具列可「重整」「變更」。
- 安全：僅接受 http/https（其他 scheme 直接拒絕）；iframe 帶 `sandbox="allow-scripts allow-same-origin allow-forms allow-popups"`（不給 top-navigation / downloads）與 `referrerPolicy="no-referrer"`。
- 目標站若送 `X-Frame-Options` / CSP `frame-ancestors` 拒絕內嵌，瀏覽器會擋下（面板空白）——輸入頁已註明此限制。
- Popout 未支援（保持 PR 最小；如需要可後續加）。

## 驗證

- `tsc -b` 乾淨、`vite build` 成功、dev server 頁面正常載入。
- 面板 UI 的手動點測（新增 → 輸入 URL → 內嵌/重整/變更/持久化）尚待補：歡迎 reviewer 以 `pnpm dev` 實測，我也會在本機測完回報結果到這串。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QD6fkFiRYU3QiD8kitmo1x