### PR TITLE
fix(installer): Windows 安裝程式增加「目前使用者／所有使用者」安裝範圍選擇

### DIFF
--- a/.github/tauri.windows.conf.json
+++ b/.github/tauri.windows.conf.json
@@ -1,0 +1,9 @@
+{
+  "bundle": {
+    "windows": {
+      "nsis": {
+        "installMode": "both"
+      }
+    }
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,20 @@ jobs:
           mv desktop_modules/src-tauri src-tauri
           rm -rf desktop_modules ~/.ssh/agent_key
 
+      # NSIS defaults to a per-user install resolved against the elevating
+      # account: on corporate machines where UAC credentials belong to a
+      # different admin user, the whole installer runs as that account, so the
+      # app lands in C:\Users\<admin>\AppData\Local (unreadable by the actual
+      # user) with shortcuts and the uninstall entry in the wrong profile.
+      # installMode "both" adds an install-scope page, so elevated installs
+      # can target Program Files (per-machine) while personal machines keep
+      # the per-user option. The overlay is copied next to tauri.conf.json,
+      # where Tauri merges platform config files automatically.
+      - name: Apply Windows installer config (NSIS installMode both)
+        if: matrix.platform == 'windows-latest'
+        shell: bash
+        run: cp .github/tauri.windows.conf.json src-tauri/tauri.windows.conf.json
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10


### PR DESCRIPTION
Fixes #23

公司電腦上一般帳號沒有安裝權限，UAC 以另一組管理員帳號提權後，NSIS 的 per-user 安裝
（installMode 預設 currentUser）會把 App 裝進提權帳號的 profile：路徑、捷徑、
解除安裝登錄全在 `C:\Users\<管理員帳號>\` 底下，實際使用者無法啟動也無法移除。

## 修法

因 `src-tauri` 已移入私有 repo，這裡採 Tauri 官方的平台覆蓋檔機制：
公開 repo 放 `.github/tauri.windows.conf.json`（`installMode: "both"`，安裝時多一頁
讓使用者選「目前使用者／所有使用者」），release workflow 在 clone 私有 src-tauri 之後
複製為 `src-tauri/tauri.windows.conf.json`，Tauri 建置時自動合併。
若您偏好直接改私有 repo 的 tauri.conf.json，等效設定是 bundle.windows.nsis.installMode = "both"，
這個 PR 可直接關閉。

## 已驗證與未驗證

- 已確認 App 執行期無任何安裝路徑依賴（sidecar 以執行檔目錄解析、設定與憑證走使用者家目錄）
- overlay JSON 與修改後的 workflow 都通過格式驗證；installMode 欄位對照 @tauri-apps/cli 的 config schema 確認存在
- 未驗證：既有 per-user 安裝在改為 both 之後的靜默更新是否多跳 UAC，需一次實際打包驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)