### PR TITLE
feat(stream): 上游行情停滯偵測與 STALE 狀態（半自動，Fixes #28）

### DIFF
--- a/src/components/debug-panel.tsx
+++ b/src/components/debug-panel.tsx
@@ -19,7 +19,12 @@ import { appVersion } from '../lib/tauri';
 import * as dockStyles from './bottom-dock.css';
 import * as styles from './debug-panel.css';
 
-const STATUS_LABEL = { live: 'LIVE', connecting: 'SYNC', down: 'LOST' };
+const STATUS_LABEL = {
+    live: 'LIVE',
+    connecting: 'SYNC',
+    stale: 'STALE',
+    down: 'LOST',
+};
 
 export function DebugPanel() {
     const stream = useStreamStatus();

--- a/src/components/flash-order.tsx
+++ b/src/components/flash-order.tsx
@@ -16,7 +16,11 @@ import {
     useRef,
     useState,
 } from 'react';
-import { useQuote, useTradingLive } from '../hooks/use-stream';
+import {
+    useQuote,
+    useStreamStatus,
+    useTradingLive,
+} from '../hooks/use-stream';
 import { maskMoney, usePrivacyMoney } from '../lib/privacy';
 import { cancelOrder } from '../lib/shioaji';
 import { getAliasFor, onOrderEvent } from '../lib/stream';
@@ -180,6 +184,7 @@ export function FlashOrder({
 }) {
     const quote = useQuote(contract.code);
     const live = useTradingLive();
+    const streamStatus = useStreamStatus();
     const privMoney = usePrivacyMoney();
     const [qty, setQty] = useState(1);
     const [armed, setArmed] = useState(false);
@@ -608,7 +613,11 @@ export function FlashOrder({
                     onClick={() => setArmed((a) => !a)}
                 >
                     {!live ? (
-                        '⚠ 未連線'
+                        streamStatus === 'stale' ? (
+                            '⚠ 行情停滯'
+                        ) : (
+                            '⚠ 未連線'
+                        )
                     ) : armed ? (
                         <>
                             <Zap size={10} style={{ verticalAlign: '-1px' }} />{' '}

--- a/src/components/hud-header.css.ts
+++ b/src/components/hud-header.css.ts
@@ -91,6 +91,8 @@ export const led = styleVariants({
             animation: `${blink} 1s infinite`,
         },
     ],
+    // stale（本機通、上游行情停滯）：恆亮琥珀，與閃爍的 connecting 區分
+    stale: [ledBase, { background: vars.color.amber }],
     down: [
         ledBase,
         {

--- a/src/components/hud-header.tsx
+++ b/src/components/hud-header.tsx
@@ -27,6 +27,7 @@ import * as styles from './hud-header.css';
 const STATUS_LABEL = {
     live: 'LIVE',
     connecting: 'SYNC',
+    stale: 'STALE',
     down: 'LOST',
 } as const;
 

--- a/src/components/market-bar.tsx
+++ b/src/components/market-bar.tsx
@@ -1,12 +1,12 @@
 // src/components/market-bar.tsx — index / futures basis strip in the header
 
-import { useCallback } from 'react';
-import { usePoll } from '../hooks/use-poll';
+import { useSyncExternalStore } from 'react';
 import { useQuote } from '../hooks/use-stream';
 import { useHeaderItems } from '../lib/header-items';
-import { fetchSnapshots } from '../lib/shioaji';
-import { ensureContract } from '../lib/contracts-cache';
-import type { Snapshot } from '../lib/types/market';
+import {
+    getLatestSnapshots,
+    subscribeSnapshotStore,
+} from '../lib/stream-health';
 import { fmtPct, fmtPrice, fmtSigned } from '../lib/utils/format';
 import * as panel from './panel.css';
 import * as styles from './hud-header.css';
@@ -14,16 +14,9 @@ import * as styles from './hud-header.css';
 export function MarketBar() {
     // 頂欄自訂：加權/基差 chips 可各自關閉（settings → 外觀 → 頂欄顯示）
     const headerItems = useHeaderItems();
-    const { data } = usePoll<Snapshot[]>(
-        useCallback(async () => {
-            const contracts = await Promise.all([
-                ensureContract('IX0001', 'IND'),
-                ensureContract('TXFR1', 'FUT'),
-            ]);
-            return fetchSnapshots(contracts);
-        }, []),
-        10000,
-    );
+    // 快照來自 stream-health 的共用輪詢（同兩檔、同 10 秒），顯示與
+    // 失聯偵測共用一條 REST 請求，避免對 sidecar 重複打
+    const data = useSyncExternalStore(subscribeSnapshotStore, getLatestSnapshots);
     const indexLive = useQuote('IX0001');
     const txfLive = useQuote('TXFR1');
 

--- a/src/components/server-manager.tsx
+++ b/src/components/server-manager.tsx
@@ -417,22 +417,27 @@ export function ServerManager({
     // quote stream means the server is up and serving — that must beat a
     // still-pending `busy` (the sidecar `server start` can stay awaited well
     // after the daemon is live), otherwise it sticks on 啟動中 forever.
-    const phase: 'starting' | 'connecting' | 'ok' | 'down' =
+    const phase: 'starting' | 'connecting' | 'ok' | 'stale' | 'down' =
         running && stream === 'live'
             ? 'ok'
-            : stream === 'live'
-              ? 'connecting' // data flowing, health not confirmed yet
-              : busy
-                ? 'starting'
-                : status?.running || stream === 'connecting'
-                  ? 'connecting'
-                  : 'down';
+            : stream === 'stale'
+              ? 'stale' // 本機通、上游行情停滯（issue #28）：需手動重啟，
+              // 不能演成會自癒的「連線中…」
+              : stream === 'live'
+                ? 'connecting' // data flowing, health not confirmed yet
+                : busy
+                  ? 'starting'
+                  : status?.running || stream === 'connecting'
+                    ? 'connecting'
+                    : 'down';
     const phaseLabel =
         phase === 'starting'
             ? '啟動中…'
             : phase === 'connecting'
               ? '連線中…'
-              : '伺服器';
+              : phase === 'stale'
+                ? '行情停滯'
+                : '伺服器';
     const updatePercent =
         updateState.totalBytes && updateState.downloadedBytes !== undefined
             ? Math.min(
@@ -501,7 +506,15 @@ export function ServerManager({
                     <Orb size={12} variant='ring' style={{ color: 'var(--amber, #e0a43c)' }} />
                 ) : (
                     <span
-                        className={styles.led[phase === 'ok' ? 'live' : 'down']}
+                        className={
+                            styles.led[
+                                phase === 'ok'
+                                    ? 'live'
+                                    : phase === 'stale'
+                                      ? 'stale'
+                                      : 'down'
+                            ]
+                        }
                     />
                 )}
                 {updateNeedsAttention ? updateHeaderLabel : phaseLabel}
@@ -562,7 +575,11 @@ export function ServerManager({
                                 <span
                                     className={
                                         styles.led[
-                                            phase === 'ok' ? 'live' : 'down'
+                                            phase === 'ok'
+                                                ? 'live'
+                                                : phase === 'stale'
+                                                  ? 'stale'
+                                                  : 'down'
                                         ]
                                     }
                                 />
@@ -573,9 +590,11 @@ export function ServerManager({
                                   ? status?.running
                                       ? '已啟動，等待行情連線'
                                       : '連線中'
-                                  : status?.running
-                                    ? '運行中'
-                                    : '未運行'}
+                                  : phase === 'stale'
+                                    ? '上游行情停滯，請按「重啟」重建連線'
+                                    : status?.running
+                                      ? '運行中'
+                                      : '未運行'}
                         </div>
                         {status?.running && (
                             <div className={styles.srvChipRow}>

--- a/src/lib/shioaji.ts
+++ b/src/lib/shioaji.ts
@@ -448,10 +448,14 @@ function enqueueCapability(
 const CAPABILITY_TIMEOUT_MS = 10_000;
 const CAPABILITY_RETRY_DELAYS_MS = [2_000, 4_000, 8_000, 15_000];
 
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+export function withTimeout<T>(
+    promise: Promise<T>,
+    ms: number,
+    label = '訂閱請求',
+): Promise<T> {
     return new Promise((resolve, reject) => {
         const timer = setTimeout(
-            () => reject(new Error(`訂閱請求逾時（${ms / 1000} 秒）`)),
+            () => reject(new Error(`${label}逾時（${ms / 1000} 秒）`)),
             ms,
         );
         promise.then(

--- a/src/lib/stream-health.test.ts
+++ b/src/lib/stream-health.test.ts
@@ -1,0 +1,117 @@
+// src/lib/stream-health.test.ts — 假 LIVE 偵測的判定表（issue #28）。
+// 背離＝快照前進而 SSE 靜止；seq 有動一律 ok；兩者皆靜止（夜盤冷清、
+// 休市、颱風假）一律 hold，永遠不能把安靜的市場判成失聯。
+
+import { describe, expect, it } from 'vitest';
+import {
+    advanceEvidence,
+    compareBaselines,
+    type CanaryBaseline,
+    type EvidenceState,
+} from './stream-health';
+
+function baselines(
+    entries: Record<string, [snapshotDt: string, seq: number]>,
+): Map<string, CanaryBaseline> {
+    return new Map(
+        Object.entries(entries).map(([code, [snapshotDt, seq]]) => [
+            code,
+            { snapshotDt, seq },
+        ]),
+    );
+}
+
+describe('compareBaselines', () => {
+    it('快照前進而 SSE 全靜止 → stale（本案主症狀）', () => {
+        const prev = baselines({
+            IX0001: ['2026-08-20T10:00:00', 5],
+            TXFR1: ['2026-08-20T10:00:01', 9],
+        });
+        const next = baselines({
+            IX0001: ['2026-08-20T10:00:10', 5],
+            TXFR1: ['2026-08-20T10:00:11', 9],
+        });
+        expect(compareBaselines(prev, next)).toBe('stale');
+    });
+
+    it('任一商品 seq 有動 → ok（串流活著，即使另一商品快照前進）', () => {
+        const prev = baselines({
+            IX0001: ['2026-08-20T10:00:00', 5],
+            TXFR1: ['2026-08-20T10:00:01', 9],
+        });
+        const next = baselines({
+            IX0001: ['2026-08-20T10:00:10', 5],
+            TXFR1: ['2026-08-20T10:00:11', 10],
+        });
+        expect(compareBaselines(prev, next)).toBe('ok');
+    });
+
+    it('快照與 seq 都沒動 → hold（夜盤冷清、休市、颱風假）', () => {
+        const prev = baselines({
+            IX0001: ['2026-08-20T13:33:00', 5],
+            TXFR1: ['2026-08-20T13:44:59', 9],
+        });
+        const next = baselines({
+            IX0001: ['2026-08-20T13:33:00', 5],
+            TXFR1: ['2026-08-20T13:44:59', 9],
+        });
+        expect(compareBaselines(prev, next)).toBe('hold');
+    });
+
+    it('只有單一商品的快照前進、SSE 靜止 → 仍是 stale', () => {
+        // 夜盤只有台指期在動（指數收盤停更）也要能偵測
+        const prev = baselines({
+            IX0001: ['2026-08-20T13:33:00', 5],
+            TXFR1: ['2026-08-20T22:15:00', 9],
+        });
+        const next = baselines({
+            IX0001: ['2026-08-20T13:33:00', 5],
+            TXFR1: ['2026-08-20T22:16:30', 9],
+        });
+        expect(compareBaselines(prev, next)).toBe('stale');
+    });
+
+    it('新出現的商品（上一輪沒有基準）不參與判定', () => {
+        const prev = baselines({ IX0001: ['2026-08-20T10:00:00', 5] });
+        const next = baselines({
+            IX0001: ['2026-08-20T10:00:00', 5],
+            TXFR1: ['2026-08-20T10:00:11', 9],
+        });
+        expect(compareBaselines(prev, next)).toBe('hold');
+    });
+
+    it('空基準（快照整批失敗過）→ hold，不會誤判', () => {
+        expect(compareBaselines(new Map(), new Map())).toBe('hold');
+    });
+});
+
+describe('advanceEvidence', () => {
+    const run = (start: EvidenceState, verdicts: string[]) =>
+        verdicts.reduce(
+            (s, v) => advanceEvidence(s, v as 'stale' | 'ok' | 'hold'),
+            start,
+        );
+
+    it('連續背離累積、ok 全歸零', () => {
+        expect(run({ streak: 0, holdRun: 0 }, ['stale', 'stale'])).toEqual({
+            streak: 2,
+            holdRun: 0,
+        });
+        expect(run({ streak: 2, holdRun: 0 }, ['ok'])).toEqual({
+            streak: 0,
+            holdRun: 0,
+        });
+    });
+
+    it('hold 連續三輪把累積歸零：相隔數小時的兩次單輪背離不能湊成連續', () => {
+        // 收盤瞬間一輪背離 → 整個休市 hold → 開盤重放空窗再一輪背離，
+        // 不可以觸發（歸零後 streak 只有 1）
+        const closed = run({ streak: 1, holdRun: 0 }, ['hold', 'hold', 'hold']);
+        expect(closed.streak).toBe(0);
+        expect(run(closed, ['stale']).streak).toBe(1);
+    });
+
+    it('短暫 hold（一兩輪）不影響背離累積', () => {
+        expect(run({ streak: 1, holdRun: 0 }, ['hold', 'stale']).streak).toBe(2);
+    });
+});

--- a/src/lib/stream-health.ts
+++ b/src/lib/stream-health.ts
@@ -1,0 +1,253 @@
+// src/lib/stream-health.ts — 盤中「假 LIVE」偵測（issue #28）。
+// LIVE 只證明 webview 到本機 sidecar 的 SSE 通；sidecar 對上游的行情
+// session 死掉時 heartbeat 照發、燈照綠。這裡用「同商品的 REST 快照
+// datetime 有前進、SSE 端卻沒有任何更新」的相對背離當失聯證據：快照與
+// 串流同源（同一顆 sidecar、同一個上游），快照會前進代表市場開著且上游
+// 可達，此時 SSE 靜止只可能是行情串流側失聯。夜盤冷清、休市、颱風假時
+// 快照同樣不前進，自然落在「不判定」分支，毋須交易時段表與假日特判。
+//
+// 這裡同時是快照的唯一輪詢者：最新結果放進可訂閱 store 供 MarketBar
+// 顯示（原本 MarketBar 自己每 10 秒輪詢同兩檔，共用後 API 用量不變）。
+
+import { ensureContract } from './contracts-cache';
+import { fetchSnapshots, withTimeout } from './shioaji';
+import {
+    getLastUpstreamDataAt,
+    getQuote,
+    getStreamStatus,
+    markStreamStale,
+    onContractEvent,
+} from './stream';
+import { isTauri } from './runtime';
+import { notify } from './trade';
+import type { SecurityType } from './types/contract';
+import type { Snapshot } from './types/market';
+
+// 與 MarketBar 相同的基準商品（contracts-cache 已常駐訂閱其行情）：
+// 加權指數盤中每 5 秒固定發布、台指期日盤實測每分鐘皆有成交。
+// 快照回傳的 code 實測就是請求的顯示代碼（TXFR1 原樣回傳），直接比對。
+const CANARY_CODES: ReadonlyArray<{ code: string; type: SecurityType }> = [
+    { code: 'IX0001', type: 'IND' },
+    { code: 'TXFR1', type: 'FUT' },
+];
+
+const POLL_MS = 10_000;
+const SNAPSHOT_TIMEOUT_MS = 5_000;
+// 連續兩輪背離（約 20 秒）才判定，單輪可能撞上訂閱重放的空窗
+const STALE_ROUNDS = 2;
+// hold（無新證據）連續超過此輪數就把累積歸零：兩次相隔數小時的
+// 單輪背離（收盤瞬間、開盤重放空窗）不可以被湊成「連續」
+const HOLD_RESET_ROUNDS = 3;
+// SSE 重連（onopen 必發 RECONNECT）與維護窗後的緩衝：訂閱重放逐筆
+// 序列進行、warmup 期會 hang（shioaji.ts 註解記載的實案），期間快照
+// 前進而 SSE 靜止是合法過渡，不能當失聯證據。開機首次連線同樣適用。
+const RECONNECT_GRACE_MS = 60_000;
+
+export interface CanaryBaseline {
+    snapshotDt: string; // 快照的 datetime（同格式字串可直接比大小）
+    seq: number; // stream store 的更新序號（任何 tick/bidask/index 都會動）
+}
+
+export type HealthVerdict = 'stale' | 'ok' | 'hold';
+
+// 純判定函式（供測試）。背離＝至少一個基準商品的快照 datetime 前進、
+// 且所有基準商品的 SSE seq 都沒動。seq 有動＝串流活著（ok，歸零重計）；
+// 快照與 seq 都沒動＝市場安靜或休市，證據不足（hold）。
+export function compareBaselines(
+    prev: ReadonlyMap<string, CanaryBaseline>,
+    next: ReadonlyMap<string, CanaryBaseline>,
+): HealthVerdict {
+    let snapshotAdvanced = false;
+    for (const [code, current] of next) {
+        const before = prev.get(code);
+        if (!before) continue;
+        if (current.seq > before.seq) return 'ok';
+        if (current.snapshotDt > before.snapshotDt) snapshotAdvanced = true;
+    }
+    return snapshotAdvanced ? 'stale' : 'hold';
+}
+
+export interface EvidenceState {
+    streak: number; // 連續背離輪數
+    holdRun: number; // 連續無證據輪數
+}
+
+// 純累積函式（供測試）：stale 累積、ok 全歸零、hold 連續太久也歸零
+export function advanceEvidence(
+    state: EvidenceState,
+    verdict: HealthVerdict,
+): EvidenceState {
+    if (verdict === 'ok') return { streak: 0, holdRun: 0 };
+    if (verdict === 'stale') return { streak: state.streak + 1, holdRun: 0 };
+    const holdRun = state.holdRun + 1;
+    return {
+        streak: holdRun >= HOLD_RESET_ROUNDS ? 0 : state.streak,
+        holdRun,
+    };
+}
+
+// ---- 快照 store（MarketBar 顯示與偵測共用同一條輪詢）----
+
+let latestSnapshots: Snapshot[] | undefined;
+const snapshotListeners = new Set<() => void>();
+
+export function subscribeSnapshotStore(listener: () => void) {
+    snapshotListeners.add(listener);
+    ensurePolling();
+    return () => {
+        snapshotListeners.delete(listener);
+    };
+}
+
+export function getLatestSnapshots(): Snapshot[] | undefined {
+    return latestSnapshots;
+}
+
+// ---- 偵測引擎 ----
+
+let pollingStarted = false;
+let alarmEnabled = false;
+
+let prev: Map<string, CanaryBaseline> | null = null;
+let evidence: EvidenceState = { streak: 0, holdRun: 0 };
+let noticed = false;
+let graceUntil = 0;
+let lastSeenDataAt = 0;
+let ticking = false;
+
+function resetEvidence() {
+    prev = null;
+    evidence = { streak: 0, holdRun: 0 };
+}
+
+async function tick() {
+    // async tick 不可重入（repo 慣例，見 boot.ts 的 overlapping-ticks）
+    if (ticking) return;
+    ticking = true;
+    try {
+        let snapshots: Snapshot[];
+        try {
+            const contracts = await withTimeout(
+                Promise.all(
+                    CANARY_CODES.map((c) => ensureContract(c.code, c.type)),
+                ),
+                SNAPSHOT_TIMEOUT_MS,
+                '合約解析',
+            );
+            snapshots = await withTimeout(
+                fetchSnapshots(contracts),
+                SNAPSHOT_TIMEOUT_MS,
+                '快照請求',
+            );
+        } catch {
+            // 快照失敗可能是本機斷網或 sidecar/token 層問題，證據不足：
+            // 不累積也不歸零（多等一輪的成本遠低於誤判）
+            return;
+        }
+        latestSnapshots = snapshots;
+        snapshotListeners.forEach((l) => l());
+
+        if (!alarmEnabled) return;
+        // 只在 live/stale 時判定；down/connecting 由既有重連迴圈負責
+        const status = getStreamStatus();
+        if (status !== 'live' && status !== 'stale') {
+            resetEvidence();
+            noticed = false;
+            return;
+        }
+        // 背景視窗（WebView2 節流 timer）與斷網（本機問題）不累積證據
+        if (document.hidden || navigator.onLine === false) return;
+
+        // 任何 SSE 行情有進來（不限基準商品）就是串流活著的鐵證，
+        // 也擋掉「基準商品訂閱卡住但其他訂閱正常」的誤判
+        const dataAt = getLastUpstreamDataAt();
+        const dataFlowed = dataAt !== lastSeenDataAt;
+        lastSeenDataAt = dataAt;
+
+        const next = new Map<string, CanaryBaseline>();
+        for (const snapshot of snapshots) {
+            if (!snapshot.datetime) continue;
+            if (!CANARY_CODES.some((c) => c.code === snapshot.code)) continue;
+            next.set(snapshot.code, {
+                snapshotDt: snapshot.datetime,
+                seq: getQuote(snapshot.code)?.seq ?? 0,
+            });
+        }
+        const verdict: HealthVerdict = dataFlowed
+            ? 'ok'
+            : prev
+              ? compareBaselines(prev, next)
+              : 'hold';
+        prev = next;
+
+        if (Date.now() < graceUntil) {
+            // 重連/開機緩衝期：訂閱重放中，背離是合法過渡
+            evidence = { streak: 0, holdRun: 0 };
+            return;
+        }
+        evidence = advanceEvidence(evidence, verdict);
+
+        if (verdict === 'ok' && noticed) {
+            noticed = false;
+            notify({
+                kind: 'ok',
+                title: '行情串流已恢復',
+                body: '即時行情已重新抵達，恢復 LIVE。',
+            });
+        }
+        if (evidence.streak >= STALE_ROUNDS) {
+            // 每輪重標（冪等）：本機 SSE 重連的 onopen 會把狀態洗回
+            // live，其他視窗也可能各自被洗掉，靠重標與重廣播拉回
+            markStreamStale();
+            if (!noticed) {
+                noticed = true;
+                notify({
+                    kind: 'err',
+                    title: '行情串流疑似失聯',
+                    body:
+                        '快照持續更新但即時行情靜止，上游行情連線可能已中斷，下單已暫停保護。' +
+                        (isTauri
+                            ? '請點頂部「伺服器」開啟面板，按「重啟」重建連線。'
+                            : '請重新整理頁面，或檢查 shioaji server 的行情連線。'),
+                });
+            }
+        }
+    } finally {
+        ticking = false;
+    }
+}
+
+function ensurePolling() {
+    if (pollingStarted) return;
+    pollingStarted = true;
+    void tick();
+    setInterval(() => {
+        void tick();
+    }, POLL_MS);
+}
+
+export function startStreamHealthWatch() {
+    // 與 boot.ts 相同的主視窗判斷：popout/閃電視窗不跑偵測（它們經
+    // BroadcastChannel 接收主視窗的 stale），也不主動輪詢快照（若其
+    // 版面有 MarketBar，訂閱 store 時才會就地啟動輪詢，成本與改動前
+    // MarketBar 自己輪詢相同）
+    if (new URLSearchParams(window.location.search).has('popout')) return;
+    alarmEnabled = true;
+
+    // SSE 每次 onopen 必發 RECONNECT、維護窗發 MAINTENANCE：兩者都代表
+    // 訂閱正在重放，清掉舊基準並給緩衝期，把「剛恢復的串流」誤判成
+    // 失聯的窗口關掉。開機首次連線同樣走這裡（等於開機緩衝）。
+    onContractEvent((event) => {
+        if (event.action === 'RECONNECT' || event.action === 'MAINTENANCE') {
+            resetEvidence();
+            graceUntil = Date.now() + RECONNECT_GRACE_MS;
+        }
+    });
+
+    // 視窗被遮蔽時 WebView2 會節流 timer，回前景後基準已過期，重置重計
+    document.addEventListener('visibilitychange', () => {
+        resetEvidence();
+    });
+
+    ensurePolling();
+}

--- a/src/lib/stream.ts
+++ b/src/lib/stream.ts
@@ -10,7 +10,10 @@ import {
     type OrderEventReport,
 } from './order-report';
 
-export type StreamStatus = 'connecting' | 'live' | 'down';
+// 'stale'：本機 SSE 連線正常（heartbeat 仍在跳）但上游行情已停止抵達，
+// 由 stream-health 的快照/SSE 背離偵測標記（issue #28）。只有真實行情
+// 事件能解除 stale（heartbeat 是 sidecar 自產的 keep-alive，證明不了上游）。
+export type StreamStatus = 'connecting' | 'live' | 'stale' | 'down';
 
 export interface ContractChangeEvent {
     event_id: string;
@@ -125,6 +128,39 @@ function setStatus(s: StreamStatus) {
     }
 }
 
+// 上游行情實際抵達，這是 stale 唯一的復原證據
+let lastUpstreamDataAt = 0;
+function noteUpstreamData() {
+    lastUpstreamDataAt = Date.now();
+    if (status === 'stale') setStatus('live');
+}
+
+export function getLastUpstreamDataAt(): number {
+    return lastUpstreamDataAt;
+}
+
+// stale 判定只在主視窗跑（stream-health），但閃電/popout 視窗是獨立的
+// JS context、各有一份本模組與下單閘門，用 BroadcastChannel 把降級
+// 同步過去（跨視窗先例：option-pick 的 sj-opt-pick）。復原不需廣播：
+// 上游恢復後各視窗自己的 SSE 就會收到行情，noteUpstreamData 就地解除。
+const staleChannel =
+    typeof BroadcastChannel !== 'undefined'
+        ? new BroadcastChannel('sj-stream-stale')
+        : null;
+staleChannel?.addEventListener('message', () => {
+    if (status === 'live') setStatus('stale');
+});
+
+// stream-health 判定上游失聯時降級。只降 live（down/connecting 已由
+// 既有重連迴圈負責，蓋掉會讓兩套機制互相打架）。呼叫端在失聯持續期間
+// 每輪重呼（setStatus 已去重）：本機 SSE 任何一次重連的 onopen 都會把
+// 狀態洗回 live，靠週期性重標把它拉回 stale，廣播同理（其他視窗可能
+// 剛被自己的重連洗掉）。
+export function markStreamStale() {
+    if (status === 'live') setStatus('stale');
+    staleChannel?.postMessage('stale');
+}
+
 function handleTick(raw: string) {
     const tick = JSON.parse(raw) as SseTick;
     if (tick.intraday_odd) return; // board shows regular-lot stream only
@@ -134,6 +170,7 @@ function handleTick(raw: string) {
 }
 
 function ingestTick(tick: SseTick) {
+    noteUpstreamData();
     const prev = quotes.get(tick.code);
     const prevClose = prev?.tick ? Number(prev.tick.close) : undefined;
     const close = Number(tick.close);
@@ -168,6 +205,7 @@ function handleBidAsk(raw: string) {
 }
 
 function ingestBidAsk(bidask: SseBidAsk) {
+    noteUpstreamData();
     const prev = quotes.get(bidask.code);
     quotes.set(bidask.code, {
         tick: prev?.tick,
@@ -246,6 +284,7 @@ export function normalizeIndexQuote(raw: string): SseIndexQuote {
 function handleIndexQuote(raw: string) {
     const index = normalizeIndexQuote(raw);
     if (!index.code || !Number.isFinite(Number(index.close))) return;
+    noteUpstreamData();
     const prev = quotes.get(index.code);
     const previousClose = prev?.index ? Number(prev.index.close) : undefined;
     const close = Number(index.close);
@@ -418,7 +457,9 @@ function connect() {
     });
     es.addEventListener('heartbeat', () => {
         lastHeartbeat = Date.now();
-        setStatus('live');
+        // heartbeat 是 sidecar 自產的 keep-alive，只證明本機層活著，
+        // 不能解除 stale（上游失聯時 heartbeat 照常抵達）
+        if (status !== 'stale') setStatus('live');
     });
     for (const name of namedListeners.keys()) {
         attachNamed(es, name);

--- a/src/lib/trade.ts
+++ b/src/lib/trade.ts
@@ -81,7 +81,15 @@ export function isFuturesContract(contract: ContractBase): boolean {
 // (esp. with real money on the line) must not think a click went through
 // when it didn't (issue #2). UI also disables the buttons; this backs it up.
 export function assertTradingLive() {
-    if (getStreamStatus() !== 'live') {
+    const status = getStreamStatus();
+    // stale：本機連線是通的、等待不會恢復（issue #28），指引要與
+    // stream-health 的通知一致（手動重啟），不能叫使用者乾等
+    if (status === 'stale') {
+        throw new Error(
+            '上游行情停滯（STALE），已暫停下單保護，請到「伺服器」面板按「重啟」重建連線',
+        );
+    }
+    if (status !== 'live') {
         throw new Error('行情未連線（非 LIVE）— 為避免誤單已暫停下單，請待連線恢復');
     }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,7 @@ import { OnboardingSetup } from './components/onboarding-setup';
 import './index.css';
 import { startAnalytics } from './lib/analytics';
 import { bootstrap } from './lib/boot';
+import { startStreamHealthWatch } from './lib/stream-health';
 import { isTauri, loadDesktopSettings } from './lib/tauri';
 import { initTheme } from './lib/theme-store';
 import { startTriggerEngine } from './lib/trigger-engine';
@@ -18,6 +19,7 @@ initTheme();
 startAnalytics();
 startTriggerEngine();
 bootstrap();
+startStreamHealthWatch();
 
 // A fresh desktop install has no API key saved yet — the dashboard would
 // otherwise render fully but every panel silently fails against a server


### PR DESCRIPTION
上游行情 session 死掉、sidecar 活著時，App 目前全綠且下單閘門照開（#28）。本 PR 是 issue 修法方向「訴求二」的前端半自動版：**偵測到就誠實降級、暫停下單、告警指引手動重啟**。刻意不做自動重啟（誤判成本高、且會被 attach 短路，詳見 issue 訴求三），留作後續 opt-in。

## 做了什麼

- `StreamStatus` 增加第四狀態 **`stale`**（本機 SSE 通、上游行情停滯）。徽章顯示 STALE（恆亮琥珀，與閃爍的 SYNC 區分）、伺服器按鈕顯示「行情停滯」與重啟指引、debug 面板同步。
- **偵測**（新檔 `src/lib/stream-health.ts`）：同商品「REST 快照 datetime 前進、SSE 卻零更新」的相對背離，連續兩輪（約 20 秒）判定。快照與串流同源，快照前進＝市場開著且上游可達，此時 SSE 靜止只可能是串流側失聯。夜盤冷清、休市、颱風假時快照不前進，天然不判定，毋須交易時段表。
- **下單保護**：`assertTradingLive` 沿用非 live 即擋的既有語意自動生效；stale 專屬文案指引重啟（而非「請待連線恢復」的乾等）。閃電下單 armed 自動解除、按鈕顯示「行情停滯」。
- **跨視窗**：stale 經 BroadcastChannel（`sj-stream-stale`，沿用 option-pick 先例）同步到 popout/閃電視窗，讓它們的下單閘門一起降級；且失聯持續期間每輪重標，抵抗任一視窗 SSE 重連 onopen 把狀態洗回 live。
- **通知中心**：告警與復原各一則（去重），留下客服可查的時間軸。
- 快照輪詢與 MarketBar **合併為單一 store**（同兩檔、同 10 秒），對 sidecar 的 REST 用量不變。

## 防誤判設計（重點審這裡）

| 情境 | 防護 |
|---|---|
| SSE 重連後訂閱重放空窗（可達數十秒） | onopen 必發的 RECONNECT／維護窗 MAINTENANCE 事件觸發基準重置＋60 秒緩衝 |
| 開機 warmup（subscribe 會 hang 的已知實案） | 首次連線同樣走 RECONNECT 緩衝；且任何 SSE 行情抵達（不限基準商品）即判活著 |
| 收盤瞬間／開盤空窗的單輪背離相隔數小時 | hold 連續三輪即歸零，「連續兩輪」是真連續（`advanceEvidence` 有測試鎖語意） |
| 快照請求失敗／逾時（斷網、token 層） | 證據不足：不累積也不歸零；請求包 5 秒 timeout |
| 背景視窗 timer 被 WebView2 節流 | `document.hidden` 不累積；visibilitychange 重置基準 |
| heartbeat 誤復活 | heartbeat 不再能解除 stale（sidecar 自產 keep-alive 證明不了上游）；復原唯一路徑是真實行情事件 |

## 驗證

- Vitest 75/75（新增 `compareBaselines` 與 `advanceEvidence` 判定表 9 例）、`tsc` 乾淨、`pnpm build` 通過。
- 快照 code 對齊已對實際 server（1.7.2）驗證：請求 TXFR1 回傳 code 就是 `TXFR1`（顯示代碼原樣），直接比對即可。
- 門檻的實證：近 7 個交易日 1 分 K 實測，台指期日盤每分鐘皆有成交、夜盤最長零成交靜默 2 分鐘；本 PR 的相對背離法不依賴這些門檻，數據列於 #28 供絕對門檻備援參考。
- 未驗證：上游 session 死亡時快照的實際行為（可能失敗而非回舊值），失敗分支已按「證據不足不判定」處理，不影響安全性。

若您傾向在 sidecar 端治本（#28 訴求一，讓 /health status 反映行情 session），本 PR 的偵測層屆時可降級為保險絲或直接移除，狀態機與 UI 部分仍可沿用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)