### PR TITLE
feat(chart): price-band overlay（水平價格帶）+ 內建 TXO 牆指標

### DIFF
--- a/src/components/candle-chart.tsx
+++ b/src/components/candle-chart.tsx
@@ -55,6 +55,7 @@ import {
 // 自訂指標註冊進 DEF_BY_TYPE，loadInstances() 的型別過濾才不會把它們丟掉
 import { subscribeCustoms } from '../lib/custom-indicators';
 import type { IndicatorPoint } from '../lib/indicators';
+import { PriceBandPrimitive } from '../lib/price-band';
 import { cancelOrder, fetchKbars, updateOrderPrice } from '../lib/shioaji';
 import { setPickedPrice } from '../lib/price-sync';
 import { notify, placeQuickOrder } from '../lib/trade';
@@ -788,6 +789,51 @@ export function CandleChart({
                 const st = outputStyle(inst, def, o.key);
                 if (!st.visible) continue;
                 const color = colorWithOpacity(st.color, st.opacity);
+                // 價格帶（橫式長方形區域）：透明 anchor series 供座標/legend，
+                // 實際繪製交給 PriceBandPrimitive。下緣序列在 `<key>_lo`。
+                if (o.kind === 'band') {
+                    const top = lastVal(pts);
+                    const bottom = lastVal(out[`${o.key}_lo`] ?? []);
+                    if (top === undefined || bottom === undefined) continue;
+                    const anchor = chart.addSeries(
+                        LineSeries,
+                        {
+                            color: 'rgba(0,0,0,0)',
+                            lineVisible: false,
+                            crosshairMarkerVisible: false,
+                            autoscaleInfoProvider: () => null,
+                            ...labelOpts,
+                            ...priceFormatOpt,
+                        },
+                        pane,
+                    );
+                    anchor.setData(toLineData(pts));
+                    anchor.attachPrimitive(
+                        new PriceBandPrimitive({
+                            top,
+                            bottom,
+                            fillColor: colorWithOpacity(
+                                st.color,
+                                st.opacity,
+                            ),
+                            borderColor: color,
+                            borderStyle: o.border ?? 'solid',
+                            borderWidth: st.width,
+                        }),
+                    );
+                    indSeriesRef.current.push(
+                        anchor as ISeriesApi<'Line' | 'Histogram'>,
+                    );
+                    firstSeries ??= anchor as ISeriesApi<'Line' | 'Histogram'>;
+                    metas.push({
+                        label: o.label,
+                        color: st.color,
+                        series: anchor as ISeriesApi<'Line' | 'Histogram'>,
+                        last: (top + bottom) / 2,
+                        precision: inst.precision,
+                    });
+                    continue;
+                }
                 let s: ISeriesApi<'Line' | 'Histogram' | 'Area'>;
                 if (st.plot === 'histogram') {
                     s = chart.addSeries(

--- a/src/components/custom-indicator-editor.tsx
+++ b/src/components/custom-indicator-editor.tsx
@@ -22,6 +22,7 @@ const KIND_LABEL: Record<OutputDef['kind'], string> = {
     dashed: '虛線',
     histogram: '柱狀',
     points: '圓點',
+    band: '區域帶',
 };
 
 const DEFAULT_SOURCE = `// 範例：雙 EMA 動能震盪（改成你自己的邏輯）
@@ -41,6 +42,7 @@ const HELP = [
     ['參數', 'p.參數名 — 在上方「參數」表定義，加入後可在指標設定裡調'],
     ['輸出', "plot('名稱', 序列, { kind:'line|dashed|histogram|points', color:'#rrggbb', signed:true, width:2 })"],
     ['水平線', 'hline(數值) — 副圖的參考水平線（如 RSI 的 30/70）'],
+    ['價格帶', "band('名稱', 上緣, 下緣, { color:'#rrggbb', border:'solid|dashed' }) — 主圖橫式區域，上下緣可用序列或常數"],
     ['均線', 'ta.sma(src,n)  ta.ema(src,n)  ta.wma(src,n)  ta.rma(src,n)'],
     ['統計', 'ta.stdev(src,n)  ta.highest(src,n)  ta.lowest(src,n)  ta.sum(src,n)'],
     ['動能', 'ta.change(src,n)  ta.roc(src,n)  ta.rsi(src,n)'],
@@ -142,6 +144,9 @@ export function CustomIndicatorEditor({
                             ? hint.color
                             : CUSTOM_PALETTE[i % CUSTOM_PALETTE.length]!),
                     ...(kept?.signed ?? hint.signed ? { signed: true } : {}),
+                    ...((kept?.border ?? hint.border)
+                        ? { border: (kept?.border ?? hint.border)! }
+                        : {}),
                     ...((kept?.width ?? hint.width)
                         ? { width: (kept?.width ?? hint.width) as 1 | 2 }
                         : {}),
@@ -184,6 +189,9 @@ export function CustomIndicatorEditor({
                             ? hint.color
                             : CUSTOM_PALETTE[i % CUSTOM_PALETTE.length]!),
                     ...(kept?.signed ?? hint.signed ? { signed: true } : {}),
+                    ...((kept?.border ?? hint.border)
+                        ? { border: (kept?.border ?? hint.border)! }
+                        : {}),
                     ...((kept?.width ?? hint.width)
                         ? { width: (kept?.width ?? hint.width) as 1 | 2 }
                         : {}),

--- a/src/lib/chart-indicators.ts
+++ b/src/lib/chart-indicators.ts
@@ -22,6 +22,7 @@ import {
     outputStyle,
 } from './indicator-defs';
 import type { IndicatorPoint } from './indicators';
+import { PriceBandPrimitive } from './price-band';
 import type { ChartColors } from './theme-store';
 import type { Candle } from './types/market';
 
@@ -83,6 +84,44 @@ export function renderIndicatorSeries(
             const st = outputStyle(inst, def, o.key);
             if (!st.visible) continue;
             const color = colorWithOpacity(st.color, st.opacity);
+            // 價格帶（同主圖：anchor series + PriceBandPrimitive）
+            if (o.kind === 'band') {
+                const lastDef = (arr: IndicatorPoint[]) => {
+                    for (let i = arr.length - 1; i >= 0; i--) {
+                        const v = arr[i]!.value;
+                        if (v !== undefined) return v;
+                    }
+                    return undefined;
+                };
+                const top = lastDef(pts);
+                const bottom = lastDef(out[`${o.key}_lo`] ?? []);
+                if (top === undefined || bottom === undefined) continue;
+                const anchor = chart.addSeries(
+                    LineSeries,
+                    {
+                        color: 'rgba(0,0,0,0)',
+                        lineVisible: false,
+                        crosshairMarkerVisible: false,
+                        autoscaleInfoProvider: () => null,
+                        ...quiet,
+                        ...priceFormatOpt,
+                    },
+                    pane,
+                );
+                anchor.setData(toLineData(pts));
+                anchor.attachPrimitive(
+                    new PriceBandPrimitive({
+                        top,
+                        bottom,
+                        fillColor: colorWithOpacity(st.color, st.opacity),
+                        borderColor: color,
+                        borderStyle: o.border ?? 'solid',
+                        borderWidth: st.width,
+                    }),
+                );
+                firstSeries ??= anchor;
+                continue;
+            }
             let s: ISeriesApi<'Line' | 'Histogram' | 'Area'>;
             if (st.plot === 'histogram') {
                 s = chart.addSeries(

--- a/src/lib/custom-indicators.ts
+++ b/src/lib/custom-indicators.ts
@@ -129,13 +129,18 @@ function toDef(c: CustomIndicator): IndicatorDef {
             if (res.error) throw new Error(res.error);
             const out: Record<string, IndicatorPoint[]> = {};
             for (const o of outputs) {
-                const ser = res.outputs[o.key];
-                if (!ser) continue;
-                out[o.key] = bars.map((b, i) =>
-                    ser[i] === null || ser[i] === undefined
-                        ? { time: b.time }
-                        : { time: b.time, value: ser[i]! },
-                );
+                // band 輸出多帶一條下緣序列 `<key>_lo`
+                const keys =
+                    o.kind === 'band' ? [o.key, `${o.key}_lo`] : [o.key];
+                for (const k of keys) {
+                    const ser = res.outputs[k];
+                    if (!ser) continue;
+                    out[k] = bars.map((b, i) =>
+                        ser[i] === null || ser[i] === undefined
+                            ? { time: b.time }
+                            : { time: b.time, value: ser[i]! },
+                    );
+                }
             }
             return out;
         },

--- a/src/lib/custom-runtime.ts
+++ b/src/lib/custom-runtime.ts
@@ -8,9 +8,11 @@ import type { Ser } from './ta';
 
 export interface PlotHint {
     color?: string;
-    kind?: 'line' | 'dashed' | 'histogram' | 'points';
+    kind?: 'line' | 'dashed' | 'histogram' | 'points' | 'band';
     signed?: boolean;
     width?: 1 | 2;
+    // band only: 上下緣線型
+    border?: 'solid' | 'dashed';
 }
 
 export interface CustomRunResult {
@@ -37,7 +39,7 @@ const cache = new Map<string, Compiled>();
 
 // destructure the ctx so user code reads like Pine: close / p.len / ta.sma()
 const PREAMBLE =
-    'const {bars,time,open,high,low,close,volume,hl2,hlc3,ohlc4,p,ta,plot,hline}=ctx;';
+    'const {bars,time,open,high,low,close,volume,hl2,hlc3,ohlc4,p,ta,plot,hline,band}=ctx;';
 
 function compile(source: string): Compiled {
     let fn = cache.get(source);
@@ -107,6 +109,48 @@ export function runCustom(
         if (typeof v === 'number' && Number.isFinite(v)) levels.push(v);
     };
 
+    // band('名稱', 上緣序列或常數, 下緣序列或常數, opts) — 主圖價格帶。
+    // 常數自動展開成整條序列；下緣存到 `<name>_lo`（不進 order，
+    // 由 chart 的 band 分支一起取用）。
+    const band = (
+        name: unknown,
+        upper: unknown,
+        lower: unknown,
+        opts?: PlotHint,
+    ) => {
+        if (typeof name !== 'string' || name.trim() === '') {
+            throw new Error('band() 第一個參數要是輸出名稱字串');
+        }
+        const toSer = (v: unknown, which: string): Ser => {
+            if (typeof v === 'number' && Number.isFinite(v)) {
+                return new Array<number | null>(n).fill(v);
+            }
+            if (!Array.isArray(v)) {
+                throw new Error(
+                    `band('${name}') ${which}要是序列（陣列）或數字`,
+                );
+            }
+            const ser: Ser = new Array(n).fill(null);
+            for (let i = 0; i < n; i++) {
+                const x = (v as unknown[])[i];
+                ser[i] =
+                    typeof x === 'number' && Number.isFinite(x) ? x : null;
+            }
+            return ser;
+        };
+        if (!(name in outputs)) order.push(name);
+        outputs[name] = toSer(upper, '上緣');
+        outputs[`${name}_lo`] = toSer(lower, '下緣');
+        hints[name] = {
+            kind: 'band',
+            ...(opts && typeof opts.color === 'string'
+                ? { color: opts.color }
+                : {}),
+            ...(opts?.border ? { border: opts.border } : {}),
+            ...(opts?.width ? { width: opts.width } : {}),
+        };
+    };
+
     const ctx = {
         bars,
         time: bars.time,
@@ -122,6 +166,7 @@ export function runCustom(
         ta,
         plot,
         hline,
+        band,
     };
 
     try {
@@ -135,7 +180,7 @@ export function runCustom(
     if (order.length === 0) {
         return {
             ...EMPTY,
-            error: '程式碼沒有呼叫 plot() — 至少要輸出一條序列',
+            error: '程式碼沒有呼叫 plot() / band() — 至少要輸出一條序列',
         };
     }
     return { outputs, order, hints, levels };

--- a/src/lib/indicator-defs.ts
+++ b/src/lib/indicator-defs.ts
@@ -29,7 +29,7 @@ import {
 } from './indicators';
 import type { Candle } from './types/market';
 
-export type OutputKind = 'line' | 'dashed' | 'histogram' | 'points';
+export type OutputKind = 'line' | 'dashed' | 'histogram' | 'points' | 'band';
 
 export interface ParamDef {
     key: string;
@@ -48,6 +48,9 @@ export interface OutputDef {
     width?: 1 | 2;
     // histogram only: color positive/negative halves with up/down colors
     signed?: boolean;
+    // band only: 上下緣線型（預設 solid）。band 輸出的下緣序列放在
+    // compute 回傳的 `<key>_lo`，不另立 OutputDef。
+    border?: 'solid' | 'dashed';
 }
 
 export interface IndicatorDef {
@@ -210,6 +213,42 @@ export const INDICATOR_DEFS: IndicatorDef[] = [
         compute: (b, p) => {
             const r = keltner(b, p.period!, p.atrPeriod!, p.mult!);
             return { mid: r.mid, upper: r.upper, lower: r.lower };
+        },
+    },
+    {
+        type: 'txowall',
+        label: 'WALL TXO 牆',
+        short: 'WALL',
+        desc: '選擇權 OI 牆價位區域帶——履約價手動輸入，畫成橫式長方形',
+        aliases: ['wall', 'txo', 'oi', '牆', '壓力', '支撐', '選擇權'],
+        category: 'overlay',
+        params: [
+            { key: 'callWall', label: 'Call 壓力牆', def: 45500, min: 10000, max: 60000, step: 50 },
+            { key: 'putWall', label: 'Put 支撐牆', def: 44500, min: 10000, max: 60000, step: 50 },
+            { key: 'callWall2', label: 'Call 次牆（0 不畫）', def: 0, min: 0, max: 60000, step: 50 },
+            { key: 'putWall2', label: 'Put 次牆（0 不畫）', def: 0, min: 0, max: 60000, step: 50 },
+            { key: 'halfWidth', label: '區域半寬（點）', def: 25, min: 5, max: 200, step: 5 },
+        ],
+        outputs: [
+            { key: 'call', label: 'Call牆', kind: 'band', color: '#8a2a1a', width: 2 },
+            { key: 'put', label: 'Put牆', kind: 'band', color: '#5f5c26', width: 2 },
+            { key: 'call2', label: 'Call次牆', kind: 'band', color: '#a03d2a', border: 'dashed' },
+            { key: 'put2', label: 'Put次牆', kind: 'band', color: '#7a762f', border: 'dashed' },
+        ],
+        compute: (b, p) => {
+            const out: Record<string, IndicatorPoint[]> = {};
+            const constSer = (v: number): IndicatorPoint[] =>
+                b.map((bar) => ({ time: bar.time, value: v }));
+            const band = (key: string, wall: number) => {
+                if (!(wall > 0)) return; // 0 = 不畫
+                out[key] = constSer(wall + p.halfWidth!);
+                out[`${key}_lo`] = constSer(wall - p.halfWidth!);
+            };
+            band('call', p.callWall!);
+            band('put', p.putWall!);
+            band('call2', p.callWall2!);
+            band('put2', p.putWall2!);
+            return out;
         },
     },
     // ---- 副圖震盪 ----

--- a/src/lib/price-band.ts
+++ b/src/lib/price-band.ts
@@ -1,0 +1,106 @@
+// src/lib/price-band.ts — series primitive：在主圖畫「水平價格帶」
+// （上下兩個價位之間的橫式長方形區域，整個 pane 寬）。
+// lightweight-charts v5 沒有內建 box/fill-between，這裡用官方 plugin
+// primitive 機制補上；attach 到任一 series 即可（用該 series 的價格座標）。
+// TXO 牆這類「價位區域」都走這個，不再用細線模擬。
+
+import type {
+    IPrimitivePaneRenderer,
+    IPrimitivePaneView,
+    ISeriesApi,
+    ISeriesPrimitive,
+    PrimitivePaneViewZOrder,
+    SeriesAttachedParameter,
+    SeriesType,
+    Time,
+} from 'lightweight-charts';
+
+export interface PriceBandOptions {
+    top: number; // 區域上緣價位
+    bottom: number; // 區域下緣價位
+    fillColor: string; // 半透明填色（rgba）
+    borderColor: string; // 上下緣線色
+    borderStyle: 'solid' | 'dashed';
+    borderWidth: number;
+}
+
+type DrawTarget = Parameters<IPrimitivePaneRenderer['draw']>[0];
+
+class PriceBandRenderer implements IPrimitivePaneRenderer {
+    constructor(
+        private readonly _opts: PriceBandOptions,
+        private readonly _series: ISeriesApi<SeriesType> | null,
+    ) {}
+
+    draw(target: DrawTarget): void {
+        const series = this._series;
+        if (!series) return;
+        const o = this._opts;
+        const yTop = series.priceToCoordinate(Math.max(o.top, o.bottom));
+        const yBot = series.priceToCoordinate(Math.min(o.top, o.bottom));
+        if (yTop === null || yBot === null) return;
+        target.useBitmapCoordinateSpace((scope) => {
+            const ctx = scope.context;
+            const hr = scope.horizontalPixelRatio;
+            const vr = scope.verticalPixelRatio;
+            const w = scope.bitmapSize.width;
+            const y1 = Math.round(yTop * vr);
+            const y2 = Math.round(yBot * vr);
+            // 填色（整個 pane 寬）
+            ctx.fillStyle = o.fillColor;
+            ctx.fillRect(0, y1, w, Math.max(y2 - y1, 1));
+            // 上下緣
+            ctx.strokeStyle = o.borderColor;
+            ctx.lineWidth = o.borderWidth * hr;
+            ctx.setLineDash(
+                o.borderStyle === 'dashed' ? [4 * hr, 4 * hr] : [],
+            );
+            for (const y of [y1, y2]) {
+                ctx.beginPath();
+                ctx.moveTo(0, y);
+                ctx.lineTo(w, y);
+                ctx.stroke();
+            }
+            ctx.setLineDash([]);
+        });
+    }
+}
+
+class PriceBandView implements IPrimitivePaneView {
+    constructor(private readonly _band: PriceBandPrimitive) {}
+    zOrder(): PrimitivePaneViewZOrder {
+        return 'bottom'; // 區域墊在 K 棒底下，不遮價格
+    }
+    renderer(): IPrimitivePaneRenderer {
+        return new PriceBandRenderer(this._band.options, this._band.series);
+    }
+}
+
+export class PriceBandPrimitive implements ISeriesPrimitive<Time> {
+    series: ISeriesApi<SeriesType> | null = null;
+    private readonly _views: PriceBandView[];
+    private _requestUpdate: (() => void) | null = null;
+
+    constructor(public options: PriceBandOptions) {
+        this._views = [new PriceBandView(this)];
+    }
+
+    attached(param: SeriesAttachedParameter<Time>): void {
+        this.series = param.series;
+        this._requestUpdate = param.requestUpdate;
+    }
+
+    detached(): void {
+        this.series = null;
+        this._requestUpdate = null;
+    }
+
+    applyOptions(opts: Partial<PriceBandOptions>): void {
+        this.options = { ...this.options, ...opts };
+        this._requestUpdate?.();
+    }
+
+    paneViews(): readonly IPrimitivePaneView[] {
+        return this._views;
+    }
+}


### PR DESCRIPTION
## 動機

看選擇權 OI 牆（壓力/支撐）時，用細線在主圖標價位「牆壁感」不足；
自訂指標目前只有 `plot()` / `hline()`，畫不出價位「區域」。本 PR 在
指標系統加一種通用輸出型別 `band`：在兩個價位之間畫整個圖寬的
實心長方形（墊在 K 棒底下），並附上一個吃這個型別的內建指標
「WALL TXO 牆」。

## 內容

- **`src/lib/price-band.ts`（新）** — lightweight-charts v5 series
  primitive：兩價位之間整寬填色 + 上下緣線（solid/dashed），
  `zOrder: 'bottom'` 不遮 K 棒與其他指標。
- **`OutputKind` 新增 `'band'`** — band 輸出的下緣序列放在 compute
  回傳的 `` `<key>_lo` ``，不另立 OutputDef；主圖（candle-chart）與
  回測小圖（chart-indicators）兩條渲染路徑都支援。anchor series 設
  `autoscaleInfoProvider: () => null`，牆價位在可視範圍外時不會
  硬拉縮放。
- **內建指標「WALL TXO 牆」**（overlay）— 參數：Call/Put 主牆、
  次牆履約價（0 = 不畫）、區域半寬；OI 履約價每日手動輸入。
  預設暗磚紅/暗橄欖黃、實心填色，顏色與透明度 per-output 可調。
- **自訂指標 DSL 新增 `band('名稱', 上緣, 下緣, { color, border })`**
  — 上下緣可用序列或常數（常數自動展開）；編輯器的輸出型別選單、
  說明文字與 hint 傳遞（含 `border`）同步更新。

## 驗證

- `tsc -b && vite build` 通過；vitest 66/66 綠
- 已在 web build（custom app 部署）對 TXFR1 實測：band 正確墊在
  K 棒下、次牆 0 時不畫、autosave/重載後樣式保持

🤖 Generated with [Claude Code](https://claude.com/claude-code)