### PR TITLE
chore(governance): DEV/RELEASE 規範＋PR CI＋tag 即版本發佈基建

### DIFF
--- a/.github/actions/desktop-overlay/action.yml
+++ b/.github/actions/desktop-overlay/action.yml
@@ -1,0 +1,40 @@
+# 以唯讀 deploy key 拉取私有 repo（shioaji-pro-desktop）指定 SHA，
+# 疊入 modules/ 與 src-tauri/。release build 與 desktop-ci 共用同一份 —
+# 兩邊 overlay 行為若分岔，合成驗證的不變量就失真（PR #40 review S1/R1）。
+name: Overlay desktop modules
+description: Fetch the private desktop repo at an exact SHA and overlay modules/ + src-tauri/
+
+inputs:
+  ssh-key:
+    description: read-only deploy key for the private repo
+    required: true
+  sha:
+    description: full 40-char commit SHA to fetch
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        SSH_KEY: ${{ inputs.ssh-key }}
+        DESKTOP_SHA: ${{ inputs.sha }}
+      run: |
+        set -o pipefail
+        if [ "${#DESKTOP_SHA}" -ne 40 ]; then
+          echo "desktop-overlay: invalid sha '${DESKTOP_SHA}'" >&2
+          exit 1
+        fi
+        mkdir -p ~/.ssh
+        echo "$SSH_KEY" > ~/.ssh/agent_key
+        chmod 600 ~/.ssh/agent_key
+        ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+        mkdir desktop_modules && cd desktop_modules
+        git init -q
+        GIT_SSH_COMMAND="ssh -i ~/.ssh/agent_key -o IdentitiesOnly=yes" \
+          git fetch -q --depth 1 git@github.com:Yvictor/shioaji-pro-desktop.git "$DESKTOP_SHA"
+        git checkout -q FETCH_HEAD
+        cd ..
+        mv desktop_modules/modules modules
+        mv desktop_modules/src-tauri src-tauri
+        rm -rf desktop_modules ~/.ssh/agent_key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+# PR 品質門檻 — main 的 required status check（docs/DEV.md）。
+# 純前端檢查，不碰私有 repo；桌面合成驗證見 desktop-ci.yml。
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck + build
+        run: pnpm run build
+
+      - name: Unit tests
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ name: CI
 on:
   pull_request:
 
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -1,0 +1,95 @@
+# 桌面合成驗證 — 由私有 repo（shioaji-pro-desktop）的 PR 透過
+# repository_dispatch 觸發：public main ＋ 私有 PR 的 modules/src-tauri
+# 疊起來跑完整檢查，驗證「私有 main 永遠可被 release 拉去 build」的
+# 不變量（docs/DEV.md）。結果以 commit status 回報到私有 PR
+# （CI_BRIDGE_TOKEN：私有 repo 的 commit statuses:write）。
+name: Desktop CI
+
+on:
+  repository_dispatch:
+    types: [desktop-pr]
+
+jobs:
+  verify:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Report pending status
+        if: github.event.client_payload.sha != ''
+        env:
+          BRIDGE_TOKEN: ${{ secrets.CI_BRIDGE_TOKEN }}
+          SHA: ${{ github.event.client_payload.sha }}
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer $BRIDGE_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/Yvictor/shioaji-pro-desktop/statuses/$SHA" \
+            -d "{\"state\":\"pending\",\"context\":\"desktop-ci\",\"description\":\"composite verify running\",\"target_url\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+            > /dev/null || echo "status report failed (token missing?)"
+
+      - name: Overlay private modules at PR ref
+        env:
+          AGENT_SSH_KEY: ${{ secrets.AGENT_SSH_KEY }}
+          DESKTOP_SHA: ${{ github.event.client_payload.sha }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$AGENT_SSH_KEY" > ~/.ssh/agent_key
+          chmod 600 ~/.ssh/agent_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          mkdir desktop_modules && cd desktop_modules
+          git init -q
+          GIT_SSH_COMMAND="ssh -i ~/.ssh/agent_key -o IdentitiesOnly=yes" \
+            git fetch -q --depth 1 git@github.com:Yvictor/shioaji-pro-desktop.git "$DESKTOP_SHA"
+          git checkout -q FETCH_HEAD
+          cd ..
+          mv desktop_modules/modules modules
+          mv desktop_modules/src-tauri src-tauri
+          rm -rf desktop_modules ~/.ssh/agent_key
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev \
+            librsvg2-dev patchelf libgtk-3-dev
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck + build (with private modules)
+        run: pnpm run build
+
+      - name: Unit tests
+        run: pnpm test
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Cargo check
+        run: cargo check --manifest-path src-tauri/Cargo.toml
+
+      - name: Report final status
+        if: always() && github.event.client_payload.sha != ''
+        env:
+          BRIDGE_TOKEN: ${{ secrets.CI_BRIDGE_TOKEN }}
+          SHA: ${{ github.event.client_payload.sha }}
+          STATE: ${{ job.status == 'success' && 'success' || 'failure' }}
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer $BRIDGE_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/Yvictor/shioaji-pro-desktop/statuses/$SHA" \
+            -d "{\"state\":\"$STATE\",\"context\":\"desktop-ci\",\"description\":\"composite verify $STATE\",\"target_url\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
+            > /dev/null || echo "status report failed (token missing?)"

--- a/.github/workflows/desktop-ci.yml
+++ b/.github/workflows/desktop-ci.yml
@@ -1,13 +1,22 @@
-# 桌面合成驗證 — 由私有 repo（shioaji-pro-desktop）的 PR 透過
-# repository_dispatch 觸發：public main ＋ 私有 PR 的 modules/src-tauri
-# 疊起來跑完整檢查，驗證「私有 main 永遠可被 release 拉去 build」的
-# 不變量（docs/DEV.md）。結果以 commit status 回報到私有 PR
-# （CI_BRIDGE_TOKEN：私有 repo 的 commit statuses:write）。
+# 桌面合成驗證 — 兩個觸發源，守同一條不變量「私有 main 永遠可被
+# release 拉去 build」（docs/DEV.md）：
+# 1. 私有 repo（shioaji-pro-desktop）的 PR 透過 repository_dispatch 送來
+#    指定 SHA，驗完以 commit status 回報到私有 PR。
+# 2. 本 repo main 有 push 時，對私有 main HEAD 重驗 — public 側的變更
+#    也可能打破相容性，不能只在私有側變動時才驗。
+# Secrets：AGENT_SSH_KEY（唯讀 deploy key）＋ CI_BRIDGE_TOKEN（回報
+# status 用；權限見私有 repo docs/DEV.md 的 token 矩陣）。
 name: Desktop CI
 
 on:
   repository_dispatch:
     types: [desktop-pr]
+  push:
+    branches: [main]
+
+concurrency:
+  group: desktop-ci-${{ github.event.client_payload.pr || 'main' }}
+  cancel-in-progress: true
 
 jobs:
   verify:
@@ -15,37 +24,71 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # dispatch 模式：payload 必須帶 sha（發送端契約），缺了 fail-fast；
+      # push 模式：對私有 main HEAD 解析
+      - name: Resolve target desktop sha
+        id: target
+        env:
+          AGENT_SSH_KEY: ${{ secrets.AGENT_SSH_KEY }}
+          PAYLOAD_SHA: ${{ github.event.client_payload.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -o pipefail
+          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            SHA="$PAYLOAD_SHA"
+            if [ "${#SHA}" -ne 40 ]; then
+              echo "dispatch payload missing/invalid sha: '$SHA'" >&2
+              exit 1
+            fi
+          else
+            mkdir -p ~/.ssh
+            echo "$AGENT_SSH_KEY" > ~/.ssh/agent_key
+            chmod 600 ~/.ssh/agent_key
+            ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+            SHA=$(GIT_SSH_COMMAND="ssh -i ~/.ssh/agent_key -o IdentitiesOnly=yes" git ls-remote git@github.com:Yvictor/shioaji-pro-desktop.git refs/heads/main | cut -f1)
+            rm -f ~/.ssh/agent_key
+            if [ "${#SHA}" -ne 40 ]; then
+              echo "failed to resolve private main sha" >&2
+              exit 1
+            fi
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
       - name: Report pending status
-        if: github.event.client_payload.sha != ''
+        if: github.event_name == 'repository_dispatch'
         env:
           BRIDGE_TOKEN: ${{ secrets.CI_BRIDGE_TOKEN }}
-          SHA: ${{ github.event.client_payload.sha }}
+          SHA: ${{ steps.target.outputs.sha }}
         run: |
           curl -sf -X POST \
             -H "Authorization: Bearer $BRIDGE_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/Yvictor/shioaji-pro-desktop/statuses/$SHA" \
             -d "{\"state\":\"pending\",\"context\":\"desktop-ci\",\"description\":\"composite verify running\",\"target_url\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
-            > /dev/null || echo "status report failed (token missing?)"
+            > /dev/null || echo "::warning::pending status report failed"
 
-      - name: Overlay private modules at PR ref
-        env:
-          AGENT_SSH_KEY: ${{ secrets.AGENT_SSH_KEY }}
-          DESKTOP_SHA: ${{ github.event.client_payload.sha }}
+      - name: Overlay private modules
+        uses: ./.github/actions/desktop-overlay
+        with:
+          ssh-key: ${{ secrets.AGENT_SSH_KEY }}
+          sha: ${{ steps.target.outputs.sha }}
+
+      # externalBin：tauri_build 的 build script 要求 sidecar 檔案實際存在，
+      # cargo check 也會跑 build script — 與 release 同源下載（linux 一套即可）
+      - name: Resolve sidecar version
+        run: echo "SHIOAJI_VERSION=$(cat SHIOAJI_VERSION | tr -d '[:space:]')" >> "$GITHUB_ENV"
+
+      - name: Download sidecars
         run: |
-          mkdir -p ~/.ssh
-          echo "$AGENT_SSH_KEY" > ~/.ssh/agent_key
-          chmod 600 ~/.ssh/agent_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          mkdir desktop_modules && cd desktop_modules
-          git init -q
-          GIT_SSH_COMMAND="ssh -i ~/.ssh/agent_key -o IdentitiesOnly=yes" \
-            git fetch -q --depth 1 git@github.com:Yvictor/shioaji-pro-desktop.git "$DESKTOP_SHA"
-          git checkout -q FETCH_HEAD
-          cd ..
-          mv desktop_modules/modules modules
-          mv desktop_modules/src-tauri src-tauri
-          rm -rf desktop_modules ~/.ssh/agent_key
+          mkdir -p src-tauri/binaries
+          curl -fsSL -o sidecar.tar.gz \
+            "https://github.com/sinotrade/shioaji/releases/download/${SHIOAJI_VERSION}/shioaji-${SHIOAJI_VERSION}-Linux-x86_64.tar.gz"
+          tar xzf sidecar.tar.gz
+          mv shioaji src-tauri/binaries/shioaji-x86_64-unknown-linux-gnu
+          chmod +x src-tauri/binaries/shioaji-x86_64-unknown-linux-gnu
+          curl -fsSL -o src-tauri/binaries/mkcert-x86_64-unknown-linux-gnu \
+            "https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64"
+          chmod +x src-tauri/binaries/mkcert-x86_64-unknown-linux-gnu
 
       - uses: pnpm/action-setup@v4
         with:
@@ -80,11 +123,13 @@ jobs:
       - name: Cargo check
         run: cargo check --manifest-path src-tauri/Cargo.toml
 
+      # cancelled 不回報（留給接手的 run），其餘 success/failure 誠實打回；
+      # 回報失敗讓 step 紅 — CI_BRIDGE_TOKEN 過期絕不允許靜默（review A4）
       - name: Report final status
-        if: always() && github.event.client_payload.sha != ''
+        if: always() && !cancelled() && github.event_name == 'repository_dispatch' && steps.target.outputs.sha != ''
         env:
           BRIDGE_TOKEN: ${{ secrets.CI_BRIDGE_TOKEN }}
-          SHA: ${{ github.event.client_payload.sha }}
+          SHA: ${{ steps.target.outputs.sha }}
           STATE: ${{ job.status == 'success' && 'success' || 'failure' }}
         run: |
           curl -sf -X POST \
@@ -92,4 +137,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/Yvictor/shioaji-pro-desktop/statuses/$SHA" \
             -d "{\"state\":\"$STATE\",\"context\":\"desktop-ci\",\"description\":\"composite verify $STATE\",\"target_url\":\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" \
-            > /dev/null || echo "status report failed (token missing?)"
+            > /dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,33 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      desktop_sha: ${{ steps.desktop.outputs.sha }}
     steps:
       - uses: actions/checkout@v4
+      # 解析私有 repo main 的 SHA 一次 — 之後四個 build 全部釘同一顆，
+      # build 期間私有 main 變動不會造成混版；desktop-rev.txt 供發佈
+      # 追溯（下次發佈用它盤點私有側變更，見 docs/RELEASE.md）
+      - name: Resolve desktop revision
+        id: desktop
+        env:
+          AGENT_SSH_KEY: ${{ secrets.AGENT_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$AGENT_SSH_KEY" > ~/.ssh/agent_key
+          chmod 600 ~/.ssh/agent_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          SHA=$(GIT_SSH_COMMAND="ssh -i ~/.ssh/agent_key -o IdentitiesOnly=yes" git ls-remote git@github.com:Yvictor/shioaji-pro-desktop.git refs/heads/main | cut -f1)
+          rm -f ~/.ssh/agent_key
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "shioaji-pro-desktop@${SHA:0:7}" > desktop-rev.txt
+          cat desktop-rev.txt
       - name: Create draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create '${{ github.ref_name }}'             --repo '${{ github.repository }}'             --draft --title 'Shioaji Pro ${{ github.ref_name }}'             --notes-file RELEASE_NOTES.md           || echo "release already exists (re-run)"
+          gh release upload '${{ github.ref_name }}'             --repo '${{ github.repository }}' desktop-rev.txt --clobber
 
   build:
     needs: create-release
@@ -68,11 +88,43 @@ jobs:
           echo "$AGENT_SSH_KEY" > ~/.ssh/agent_key
           chmod 600 ~/.ssh/agent_key
           ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          mkdir desktop_modules && cd desktop_modules
+          git init -q
           GIT_SSH_COMMAND="ssh -i ~/.ssh/agent_key -o IdentitiesOnly=yes" \
-            git clone --depth 1 git@github.com:Yvictor/shioaji-pro-desktop.git desktop_modules
+            git fetch -q --depth 1 git@github.com:Yvictor/shioaji-pro-desktop.git '${{ needs.create-release.outputs.desktop_sha }}'
+          git checkout -q FETCH_HEAD
+          cd ..
           mv desktop_modules/modules modules
           mv desktop_modules/src-tauri src-tauri
           rm -rf desktop_modules ~/.ssh/agent_key
+
+      # Tag 即版本（docs/RELEASE.md）：從 tag 名解析版本注入 tauri.conf.json，
+      # repo 裡不存在任何版本檔；workflow_dispatch（非 tag）沿用檔內值
+      - name: Inject app version from tag (unix)
+        if: startsWith(github.ref, 'refs/tags/') && matrix.platform != 'windows-latest'
+        env:
+          APP_VERSION_REF: ${{ github.ref_name }}
+        run: |
+          export APP_VERSION="${APP_VERSION_REF#v}"
+          python3 -c "
+          import json, os
+          p = 'src-tauri/tauri.conf.json'
+          conf = json.load(open(p))
+          conf['version'] = os.environ['APP_VERSION']
+          json.dump(conf, open(p, 'w'), indent=2, ensure_ascii=False)
+          print('version ->', conf['version'])
+          "
+
+      - name: Inject app version from tag (windows)
+        if: startsWith(github.ref, 'refs/tags/') && matrix.platform == 'windows-latest'
+        shell: pwsh
+        run: |
+          $version = $env:GITHUB_REF_NAME -replace '^v', ''
+          $p = 'src-tauri/tauri.conf.json'
+          $conf = Get-Content $p -Raw | ConvertFrom-Json
+          $conf.version = $version
+          $conf | ConvertTo-Json -Depth 64 | Set-Content $p
+          Write-Host "version -> $version"
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,17 +27,32 @@ jobs:
         id: desktop
         env:
           AGENT_SSH_KEY: ${{ secrets.AGENT_SSH_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p ~/.ssh
-          echo "$AGENT_SSH_KEY" > ~/.ssh/agent_key
-          chmod 600 ~/.ssh/agent_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          SHA=$(GIT_SSH_COMMAND="ssh -i ~/.ssh/agent_key -o IdentitiesOnly=yes" git ls-remote git@github.com:Yvictor/shioaji-pro-desktop.git refs/heads/main | cut -f1)
-          rm -f ~/.ssh/agent_key
+          set -o pipefail
+          # Re-run 冪等：release 已帶 desktop-rev.txt 就沿用第一輪的 SHA —
+          # 重跑期間私有 main 可能已前進，重新解析會讓追溯與既有 assets 說謊
+          if gh release download '${{ github.ref_name }}' --repo '${{ github.repository }}' --pattern desktop-rev.txt --output desktop-rev.txt 2>/dev/null; then
+            SHA=$(sed -n '2p' desktop-rev.txt)
+            echo "reusing recorded desktop revision"
+          else
+            mkdir -p ~/.ssh
+            echo "$AGENT_SSH_KEY" > ~/.ssh/agent_key
+            chmod 600 ~/.ssh/agent_key
+            ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+            SHA=$(GIT_SSH_COMMAND="ssh -i ~/.ssh/agent_key -o IdentitiesOnly=yes" git ls-remote git@github.com:Yvictor/shioaji-pro-desktop.git refs/heads/main | cut -f1)
+            rm -f ~/.ssh/agent_key
+            # 行1＝人讀契約（short SHA）；行2＝完整 SHA（build 釘定與 re-run 沿用）
+            printf 'shioaji-pro-desktop@%s\n%s\n' "${SHA:0:7}" "$SHA" > desktop-rev.txt
+          fi
+          if [ "${#SHA}" -ne 40 ]; then
+            echo "failed to resolve desktop revision (got '$SHA')" >&2
+            exit 1
+          fi
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "shioaji-pro-desktop@${SHA:0:7}" > desktop-rev.txt
           cat desktop-rev.txt
       - name: Create draft release
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -78,53 +93,13 @@ jobs:
       - uses: actions/checkout@v4
 
       # the desktop layer (Tauri shell + AI Agent) is closed-source — pull
-      # it in via a read-only deploy key so the desktop build is complete
+      # it in via the shared overlay action, pinned to the SHA resolved once
+      # in create-release（四平台保證同一顆，與 desktop-ci 共用同段邏輯）
       - name: Checkout desktop modules (private)
-        shell: bash
-        env:
-          AGENT_SSH_KEY: ${{ secrets.AGENT_SSH_KEY }}
-        run: |
-          mkdir -p ~/.ssh
-          echo "$AGENT_SSH_KEY" > ~/.ssh/agent_key
-          chmod 600 ~/.ssh/agent_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          mkdir desktop_modules && cd desktop_modules
-          git init -q
-          GIT_SSH_COMMAND="ssh -i ~/.ssh/agent_key -o IdentitiesOnly=yes" \
-            git fetch -q --depth 1 git@github.com:Yvictor/shioaji-pro-desktop.git '${{ needs.create-release.outputs.desktop_sha }}'
-          git checkout -q FETCH_HEAD
-          cd ..
-          mv desktop_modules/modules modules
-          mv desktop_modules/src-tauri src-tauri
-          rm -rf desktop_modules ~/.ssh/agent_key
-
-      # Tag 即版本（docs/RELEASE.md）：從 tag 名解析版本注入 tauri.conf.json，
-      # repo 裡不存在任何版本檔；workflow_dispatch（非 tag）沿用檔內值
-      - name: Inject app version from tag (unix)
-        if: startsWith(github.ref, 'refs/tags/') && matrix.platform != 'windows-latest'
-        env:
-          APP_VERSION_REF: ${{ github.ref_name }}
-        run: |
-          export APP_VERSION="${APP_VERSION_REF#v}"
-          python3 -c "
-          import json, os
-          p = 'src-tauri/tauri.conf.json'
-          conf = json.load(open(p))
-          conf['version'] = os.environ['APP_VERSION']
-          json.dump(conf, open(p, 'w'), indent=2, ensure_ascii=False)
-          print('version ->', conf['version'])
-          "
-
-      - name: Inject app version from tag (windows)
-        if: startsWith(github.ref, 'refs/tags/') && matrix.platform == 'windows-latest'
-        shell: pwsh
-        run: |
-          $version = $env:GITHUB_REF_NAME -replace '^v', ''
-          $p = 'src-tauri/tauri.conf.json'
-          $conf = Get-Content $p -Raw | ConvertFrom-Json
-          $conf.version = $version
-          $conf | ConvertTo-Json -Depth 64 | Set-Content $p
-          Write-Host "version -> $version"
+        uses: ./.github/actions/desktop-overlay
+        with:
+          ssh-key: ${{ secrets.AGENT_SSH_KEY }}
+          sha: ${{ needs.create-release.outputs.desktop_sha }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -134,6 +109,24 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+
+      # Tag 即版本（docs/RELEASE.md）：從 tag 名解析版本注入 tauri.conf.json，
+      # repo 裡不存在任何版本檔；workflow_dispatch（非 tag）沿用檔內值。
+      # 單一 node 步驟四平台同路（bash + node 在所有 runner 皆可用）
+      - name: Inject app version from tag
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          node -e "
+            const fs = require('fs');
+            const p = 'src-tauri/tauri.conf.json';
+            const conf = JSON.parse(fs.readFileSync(p, 'utf8'));
+            conf.version = process.env.TAG_NAME.replace(/^v/, '');
+            fs.writeFileSync(p, JSON.stringify(conf, null, 2) + '\n');
+            console.log('version ->', conf.version);
+          "
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -1,0 +1,69 @@
+# DEV.md — 開發規範與流程（public repo）
+
+適用範圍：`Sinotrade/shioaji-pro-app`（開源前端＋release 基建）。
+桌面閉源層（Tauri shell＋AI Agent）在私有 repo `shioaji-pro-desktop`，
+該 repo 有自己的 `docs/DEV.md`，原則與本文件一致。
+
+## 治理原則
+
+1. **main 永不直接 push** — 由 `main-protect` ruleset 硬性強制。
+   所有變更（含文件、發佈 notes）一律走 PR。
+2. **main 永遠是綠的、永遠可發佈** — 任何時刻都可能對 main 打 tag 出版
+   （見 [RELEASE.md](RELEASE.md)），merge 進 main 等同宣告「可出貨」。
+3. **merge 一律 merge commit（`--merge`）** — 禁 squash / rebase。
+   保留原 commit SHA 是發佈追溯與 tag 祖先關係的前提。
+
+## 分支與 worktree
+
+- 分支命名：`feat/<slug>`、`fix/<slug>`、`refactor/<slug>`、
+  `docs/<slug>`、`chore/<slug>`；發佈分支固定 `release/vX.Y.Z`。
+- **所有開發都在 worktree 裡做**，主 checkout 的 main 永遠保持乾淨、
+  只用 `git fetch` ＋ `git merge --ff-only origin/main` 同步：
+
+  ```bash
+  git worktree add ../shioaji-pro-app.wt/<slug> -b feat/<slug>
+  # …開發、commit、push、開 PR…
+  git worktree remove ../shioaji-pro-app.wt/<slug>   # merge 後清理
+  ```
+
+  agent 開發使用內建 worktree 機制，效果等同。
+
+## PR 與 review
+
+merge 的前提，缺一不可：
+
+1. **CI 綠** — `ci.yml`（PR 觸發：`tsc -b`＋`vitest run`＋`vite build`）
+   已設為 ruleset 的 required status check，不綠 GitHub 不給 merge。
+2. **Review 過**：
+   - 維護者本人／agent 的 PR：至少一輪 AI review（`/code-review` 或
+     等效 agent review），CONFIRMED 等級的發現必須修掉或明確記錄
+     won't-fix；功能型變更照慣例過 QA agent 驗收後才進 PR。
+     滿足後允許 self-merge。
+   - 外部貢獻者的 PR：CI 綠＋維護者 review 核可。
+
+### 未來 review 規範（規劃中，尚未生效）
+
+Review 標準將逐步擴充：Gherkin 驗收測試、mutation testing、
+test coverage 門檻、quality metrics 等。落地時更新本節。
+
+## Commit 慣例
+
+- Conventional commits：`feat(scope): 描述`／`fix(...)`／`docs(...)`／
+  `chore(...)`／`refactor(...)`，內文中文、寫清楚動機與行為變化。
+- Agent 產出的 commit 附 `Co-Authored-By`。
+
+## 品質基線
+
+- 型別檢查用 `tsc -b`（不是 `--noEmit`，對 project references 那是空檢查）。
+- 單元測試 `vitest run` 必須全綠；wire 相容性（server 事件格式）變更
+  必須附真實 payload 的回歸測試。
+- 詞彙表在根目錄 [CONTEXT.md](../CONTEXT.md)；重大架構決策記
+  [docs/adr/](adr/)。設計文件在 [docs/design/](design/)。
+
+## 與私有 repo 的關係
+
+- 發佈時 CI 以唯讀 deploy key 拉取私有 repo（`modules/`＋`src-tauri/`）
+  疊進本 repo 完成桌面 build — 本 repo 的開發與發佈**不需要**私有
+  repo 權限。
+- 私有 repo 的 PR 會透過 `repository_dispatch` 觸發本 repo 的
+  `desktop-ci.yml` 做合成驗證（詳見私有 repo 的 DEV.md）。

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -28,6 +28,12 @@ gh release download v<上一版> --pattern desktop-rev.txt -O -  # 上一版的�
 release notes 必須涵蓋兩邊的變更 — 純私有側的改動也構成一次合法發佈
 （public 可以只有 notes commit）。
 
+`desktop-rev.txt` 格式：行 1 `shioaji-pro-desktop@<short-sha>`（人讀），
+行 2 完整 SHA（機器用）。**為什麼是 asset 不是 release body**：body 會被
+tauri-action 與 publish job 兩度覆寫，放 body 必被洗掉 — 不要「優化」搬家。
+**Bootstrap**：上一版早於此機制（≤ v0.1.43）沒有這個 asset — 首次改用
+私有 repo 的 log 人工盤點起點，之後就有據可查。
+
 ### 2. 前置檢查
 
 `tsc -b`、`vitest run`、`vite build` 全綠（release PR 的 CI 也會再跑一次）。
@@ -67,6 +73,8 @@ Tag 觸發 `Release Desktop App` workflow：
   上傳 `desktop-rev.txt`（內容 `shioaji-pro-desktop@<sha>`，追溯用）。
 - `build` ×4（macOS arm64/x64、Windows、Linux）：拉私有 repo 指定 SHA、
   從 tag 注入版本、build＋簽章＋上傳。
+- **Re-run 安全**：release 已帶 `desktop-rev.txt` 時，重跑會沿用第一輪
+  記錄的私有 SHA（不重新解析）— 追溯與 assets 保持一致。
 - `publish`：重建 `latest.json`、以 tag 上的 `RELEASE_NOTES.md` 套內文、
   去 draft 上線。
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,96 @@
+# RELEASE.md — 發佈規範與流程（public repo）
+
+## 原則
+
+- **發佈只有一種**：對本 repo 的 main 打 `vX.Y.Z` tag。私有 repo
+  （`shioaji-pro-desktop`）永不自行發版 — 它的變更由下一次 public tag
+  自動收割（release CI 拉其 main HEAD）。
+- **Tag 即版本**：版本號不存在任何檔案裡。release CI 從 tag 名解析
+  版本並注入 `tauri.conf.json` 後才 build。repo 裡（含私有 repo）
+  **沒有任何要 bump 的版本檔**。
+- **順序：merge 先、tag 後**。release PR 經 review merge 進 main 之後，
+  才對 main 上的 merge 結果打 tag — 出版的內容保證 review 過且在 main 上。
+- **只需 public repo 的 write 權限即可完成發佈**，全程不碰私有 repo。
+- GitHub release 標題固定 `Shioaji Pro vX.Y.Z`（CI 自動設定）。
+  事後改內文用 `gh release edit vX.Y.Z --notes-file RELEASE_NOTES.md`，
+  **絕不帶 `--title`**。
+
+## 流程
+
+### 1. 內容盤點（兩個 repo 都要看）
+
+```bash
+git log --oneline v<上一版>..HEAD                    # public 側變更
+gh release download v<上一版> --pattern desktop-rev.txt -O -  # 上一版的私有 SHA
+```
+
+私有側變更 = 私有 repo `git log <desktop-rev 記錄的 SHA>..main`。
+release notes 必須涵蓋兩邊的變更 — 純私有側的改動也構成一次合法發佈
+（public 可以只有 notes commit）。
+
+### 2. 前置檢查
+
+`tsc -b`、`vitest run`、`vite build` 全綠（release PR 的 CI 也會再跑一次）。
+
+### 3. Release notes 與截圖
+
+- `RELEASE_NOTES.md` 整檔改寫為新版本，首行 `## vX.Y.Z - 描述`
+  （這行就是 release 內文標題）。
+- 截圖存 `docs/images/release-X.Y.Z-*.png`（playwright、dark、zh-TW、
+  privacy mode，clip 面板區域；盤中拍真資料最佳），內文引用 raw URL
+  指向**新 tag**：
+  `https://raw.githubusercontent.com/Sinotrade/shioaji-pro-app/vX.Y.Z/docs/images/...`
+- 內文結尾照慣例附風險警語與下載說明段。
+
+### 4. Release PR
+
+```bash
+git worktree add ../shioaji-pro-app.wt/release-vX.Y.Z -b release/vX.Y.Z
+# commit RELEASE_NOTES.md + docs/images/*
+git push origin release/vX.Y.Z
+gh pr create --base main --head release/vX.Y.Z
+```
+
+CI 綠＋review 過 → `gh pr merge <N> --merge --delete-branch`。
+
+### 5. 打 tag（＝按下發佈鈕）
+
+```bash
+git fetch origin && git merge --ff-only origin/main   # 主 checkout 同步
+git tag vX.Y.Z && git push origin vX.Y.Z
+```
+
+Tag 觸發 `Release Desktop App` workflow：
+
+- `create-release`：建 draft release、解析私有 repo main 的 SHA
+  （之後四個 build 全部釘在這顆 SHA，不受 build 期間私有 main 變動影響）、
+  上傳 `desktop-rev.txt`（內容 `shioaji-pro-desktop@<sha>`，追溯用）。
+- `build` ×4（macOS arm64/x64、Windows、Linux）：拉私有 repo 指定 SHA、
+  從 tag 注入版本、build＋簽章＋上傳。
+- `publish`：重建 `latest.json`、以 tag 上的 `RELEASE_NOTES.md` 套內文、
+  去 draft 上線。
+
+盯 CI：`gh run watch <run-id> --exit-status --interval 30`。
+
+### 6. 驗證
+
+- `gh release view vX.Y.Z --json isDraft,name,assets`：非 draft、標題
+  `Shioaji Pro vX.Y.Z`、**18 個 assets**（v0.1.43 前為 17：dmg×2、msi、
+  setup.exe、AppImage/deb/rpm、app.tar.gz×2 及各自 .sig、latest.json；
+  新增 `desktop-rev.txt`）。
+- `latest.json`（`releases/latest/download`）：version 正確、
+  **11 個平台 key** 的 url 全指新版且 signature 齊。
+- 抽驗 notes 內截圖 raw URL 回 200。
+
+### 7. 收尾
+
+- 相關 GitHub issue 回覆（引導更新＋說明修了什麼）並關閉。
+- 內文事後要補改：`gh release edit vX.Y.Z --notes-file RELEASE_NOTES.md`
+  （不帶 `--title`；GitHub API 偶發假 500，先 `gh release view` 確認
+  是否已生效再重試）。
+
+## 出錯復原
+
+- tag 打錯／CI 失敗要重來：`gh release delete vX.Y.Z`、
+  `git push origin :refs/tags/vX.Y.Z`，修正後重打 tag。
+  **已上線（非 draft）的版本不刪** — 有問題直接出下一版。


### PR DESCRIPTION
依 grill 定案落地治理規範（詳見 docs/DEV.md、docs/RELEASE.md）：

- **文件**：DEV.md（worktree＋PR、review 定義、merge commit only）、RELEASE.md（merge 先 tag 後、tag 即版本、兩 repo 盤點、desktop-rev 追溯）
- **ci.yml**：PR 品質門檻（tsc/vitest/vite build）— merge 後設為 required status check
- **desktop-ci.yml**：私有 repo PR 的跨 repo 合成驗證（repository_dispatch 接收端）
- **release.yml**：私有 SHA 解析＋釘定（四平台同顆）、desktop-rev.txt asset、tag 版本注入 — 私有 repo 自此退出發佈流程

配套私有側 PR（dispatcher ci.yml＋DEV/RELEASE/CLAUDE.md）另開。需要人工的一步：建 fine-grained PAT `CI_BRIDGE_TOKEN` 存兩邊 secrets（見私有 DEV.md）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)