### PR TITLE
fix(flash-order): 個股期價格階梯照 tick_rule 走現股級距（#38）

### DIFF
--- a/src/components/order-ticket.tsx
+++ b/src/components/order-ticket.tsx
@@ -34,6 +34,7 @@ import {
     stockTaxRate,
 } from '../lib/utils/contract-cost';
 import { fmtPrice } from '../lib/utils/format';
+import { stepPrice } from '../lib/utils/ticksize';
 import * as panel from './panel.css';
 import * as styles from './order-ticket.css';
 
@@ -545,7 +546,14 @@ export function OrderTicket({
                             priceTouched.current = true;
                             setPrice((p) =>
                                 String(
-                                    Math.max(0, Number(p || 0) - 1),
+                                    Math.max(
+                                        0,
+                                        stepPrice(
+                                            contract,
+                                            Number(p || 0),
+                                            -1,
+                                        ),
+                                    ),
                                 ),
                             );
                             // stepper is a manual price edit — de-arm like
@@ -572,7 +580,11 @@ export function OrderTicket({
                         className={styles.stepBtn}
                         onClick={() => {
                             priceTouched.current = true;
-                            setPrice((p) => String(Number(p || 0) + 1));
+                            setPrice((p) =>
+                                String(
+                                    stepPrice(contract, Number(p || 0), 1),
+                                ),
+                            );
                             setArmed(false);
                             setSplitArmed(false);
                         }}

--- a/src/lib/utils/ticksize.test.ts
+++ b/src/lib/utils/ticksize.test.ts
@@ -1,0 +1,108 @@
+// 個股期跳動級距回歸（issue #38：閃電下單階梯只出整數價位）—
+// tick_rule=tw_stock_fut_price_band 的期貨要照現股級距跳 0.5 等。
+
+import { describe, expect, it } from 'vitest';
+import type { ContractBase, ContractInfo } from '../types/contract';
+import { roundToTick, stepPrice, tickSizeFor } from './ticksize';
+
+// issue #38 的實際合約資料（聯電期貨 202609）
+const ccfi6 = {
+    exchange: 'TAIFEX',
+    code: 'CCFI6',
+    security_type: 'FUT',
+    target_code: null,
+    tick: 0.5,
+    tick_rule: 'tw_stock_fut_price_band',
+    underlying_kind: 'S',
+    spec_kind: 'stock_fut',
+    underlying_code: '2303',
+} as ContractBase & Partial<ContractInfo>;
+
+const txf = {
+    exchange: 'TAIFEX',
+    code: 'TXFI6',
+    security_type: 'FUT',
+    target_code: null,
+    tick: 1,
+    underlying_kind: 'I',
+} as ContractBase & Partial<ContractInfo>;
+
+describe('tickSizeFor — futures', () => {
+    it('個股期 tick_rule=tw_stock_fut_price_band 走現股級距', () => {
+        expect(tickSizeFor(ccfi6, 130)).toBe(0.5); // 100–500 band
+        expect(tickSizeFor(ccfi6, 99)).toBe(0.1);
+        expect(tickSizeFor(ccfi6, 45)).toBe(0.05);
+        expect(tickSizeFor(ccfi6, 600)).toBe(1);
+        expect(tickSizeFor(ccfi6, 1200)).toBe(5);
+    });
+
+    it('指數期維持 1 點', () => {
+        expect(tickSizeFor(txf, 24000)).toBe(1);
+    });
+
+    it('缺 tick_rule 的舊資料用 underlying_kind=S 判別個股期', () => {
+        const legacy = { ...ccfi6, tick_rule: undefined, tick: undefined };
+        expect(tickSizeFor(legacy, 130)).toBe(0.5);
+    });
+
+    it('ETF 期不套現股級距，用 server 提供的 tick', () => {
+        const etfFut = {
+            ...ccfi6,
+            code: 'NYFR1',
+            tick_rule: undefined,
+            spec_kind: 'etf_fut',
+            underlying_code: '0050',
+            tick: 0.05,
+        };
+        expect(tickSizeFor(etfFut, 60)).toBe(0.05);
+    });
+
+    it('沒有任何 metadata 的期貨 fallback 到 1 點', () => {
+        const bare: ContractBase = {
+            exchange: 'TAIFEX',
+            code: 'TXFI6',
+            security_type: 'FUT',
+            target_code: null,
+        };
+        expect(tickSizeFor(bare, 24000)).toBe(1);
+    });
+});
+
+describe('stepPrice / roundToTick — 個股期', () => {
+    it('階梯以 0.5 遞增（issue #38 預期行為）', () => {
+        expect(stepPrice(ccfi6, 118, 1)).toBe(118.5);
+        expect(stepPrice(ccfi6, 118.5, 1)).toBe(119);
+        expect(stepPrice(ccfi6, 118, -1)).toBe(117.5);
+    });
+
+    it('跨 100 元級距邊界換 tick', () => {
+        expect(stepPrice(ccfi6, 99.9, 1)).toBe(100);
+        expect(stepPrice(ccfi6, 100, 1)).toBe(100.5);
+        expect(stepPrice(ccfi6, 100, -1)).toBe(99.9);
+    });
+
+    it('roundToTick 對齊 0.5 級距', () => {
+        expect(roundToTick(ccfi6, 130.3)).toBe(130.5);
+        expect(roundToTick(ccfi6, 130.2)).toBe(130);
+    });
+});
+
+describe('現股 / ETF 級距不受影響', () => {
+    const stk = {
+        exchange: 'TSE',
+        code: '2330',
+        security_type: 'STK',
+        target_code: null,
+    } as ContractBase;
+    const etf = { ...stk, code: '0050' };
+
+    it('現股級距照舊', () => {
+        expect(tickSizeFor(stk, 1200)).toBe(5);
+        expect(tickSizeFor(stk, 95)).toBe(0.1);
+    });
+
+    it('ETF 級距照舊', () => {
+        expect(tickSizeFor(etf, 45)).toBe(0.01);
+        expect(tickSizeFor(etf, 60)).toBe(0.05);
+    });
+});

--- a/src/lib/utils/ticksize.test.ts
+++ b/src/lib/utils/ticksize.test.ts
@@ -45,6 +45,26 @@ describe('tickSizeFor — futures', () => {
         expect(tickSizeFor(legacy, 130)).toBe(0.5);
     });
 
+    it('缺 tick_rule 也缺 underlying_kind 時 spec_kind=stock_fut 同樣判別', () => {
+        const legacy = {
+            ...ccfi6,
+            tick_rule: undefined,
+            tick: undefined,
+            underlying_kind: undefined,
+        };
+        expect(tickSizeFor(legacy, 130)).toBe(0.5);
+    });
+
+    it('server tick 為字串時照樣可用（1.7.x 數值字串化容錯）', () => {
+        const stringTick = {
+            ...txf,
+            code: 'ZFFR1',
+            underlying_kind: undefined,
+            tick: '0.25' as unknown as number,
+        };
+        expect(tickSizeFor(stringTick, 300)).toBe(0.25);
+    });
+
     it('ETF 期不套現股級距，用 server 提供的 tick', () => {
         const etfFut = {
             ...ccfi6,

--- a/src/lib/utils/ticksize.ts
+++ b/src/lib/utils/ticksize.ts
@@ -43,7 +43,8 @@ export function tickSizeFor(contract: TickContract, price: number): number {
             contract.tick_rule === 'tw_stock_fut_price_band' ||
             (!contract.tick_rule &&
                 !isEtfFut &&
-                contract.underlying_kind === 'S')
+                (contract.spec_kind === 'stock_fut' ||
+                    contract.underlying_kind === 'S'))
         ) {
             return stockTick(price);
         }

--- a/src/lib/utils/ticksize.ts
+++ b/src/lib/utils/ticksize.ts
@@ -1,8 +1,22 @@
 // src/lib/utils/ticksize.ts — TW market tick size tables
 
-import type { ContractBase } from '../types/contract';
+import type { ContractBase, ContractInfo } from '../types/contract';
 
-// TWSE/TPEX equities
+// 有 info metadata（TAIFEX 1.7 的 tick_rule/spec_kind 等）時能選對級距表；
+// 仍接受只有 ContractBase 的呼叫端（metadata 缺席 → 走舊 fallback）
+type TickContract = ContractBase &
+    Partial<
+        Pick<
+            ContractInfo,
+            | 'tick_rule'
+            | 'tick'
+            | 'underlying_kind'
+            | 'spec_kind'
+            | 'underlying_code'
+        >
+    >;
+
+// TWSE/TPEX equities；個股期同級距（TAIFEX tw_stock_fut_price_band）
 function stockTick(price: number): number {
     if (price < 10) return 0.01;
     if (price < 50) return 0.05;
@@ -17,14 +31,33 @@ function etfTick(price: number): number {
     return price < 50 ? 0.01 : 0.05;
 }
 
-export function tickSizeFor(contract: ContractBase, price: number): number {
-    if (contract.security_type === 'FUT') return 1; // TXF/MXF/TMF index futures
+export function tickSizeFor(contract: TickContract, price: number): number {
+    if (contract.security_type === 'FUT') {
+        // 個股期跳動跟現股同級距，以 server 的 tick_rule 為準；沒有
+        // metadata 的舊資料用 underlying_kind 'S' 判別，但要排除 ETF 期
+        // （級距不同，交給下面的 server tick fallback）
+        const isEtfFut =
+            contract.spec_kind === 'etf_fut' ||
+            (contract.underlying_code ?? '').startsWith('00');
+        if (
+            contract.tick_rule === 'tw_stock_fut_price_band' ||
+            (!contract.tick_rule &&
+                !isEtfFut &&
+                contract.underlying_kind === 'S')
+        ) {
+            return stockTick(price);
+        }
+        // 非 1 點跳動的其他期貨（ETF 期等）以 server 提供的 tick 為準
+        const t = Number(contract.tick);
+        if (Number.isFinite(t) && t > 0) return t;
+        return 1; // TXF/MXF/TMF index futures
+    }
     if (contract.security_type === 'OPT') return price >= 10 ? 1 : 0.1;
     if (contract.code.startsWith('00')) return etfTick(price);
     return stockTick(price);
 }
 
-export function roundToTick(contract: ContractBase, price: number): number {
+export function roundToTick(contract: TickContract, price: number): number {
     const tick = tickSizeFor(contract, price);
     const rounded = Math.round(price / tick) * tick;
     // avoid float dust (0.1 steps)
@@ -32,7 +65,7 @@ export function roundToTick(contract: ContractBase, price: number): number {
 }
 
 export function stepPrice(
-    contract: ContractBase,
+    contract: TickContract,
     price: number,
     steps: number,
 ): number {


### PR DESCRIPTION
## 問題（#38）

閃電下單的 `tickSizeFor` 對所有 `FUT` 一律回 1 點，個股期（如聯電期 CCFI6，tick=0.5）的價格階梯只出整數價位，少掉一半可下單的價格。

## 修法

- 以 server 1.7 contract metadata 的 `tick_rule === 'tw_stock_fut_price_band'` 判別個股期，套用與現股相同的級距表（<10:0.01 / <50:0.05 / <100:0.1 / <500:0.5 / <1000:1 / ≥1000:5），跨級距邊界時 tick 跟著換。
- 無 metadata 的舊資料 fallback：`underlying_kind === 'S'` 且非 ETF 期（`spec_kind === 'etf_fut'` 或 underlying 00 開頭者排除，其級距不同）。
- 其餘期貨以 server 提供的 `tick` 為準（ETF 期等非 1 點跳動），指數期維持 1 點。

## 驗證

- 新增 `ticksize.test.ts` 10 條回歸（含 issue 實際合約資料 CCFI6、跨 100 元級距邊界、ETF 期 fallback、指數期與現股不受影響）。
- dev app 實測：CCFI6 階梯 134.00 → 133.50 → … → 127.00 照 0.5 遞增。

🤖 Generated with [Claude Code](https://claude.com/claude-code)