### PR TITLE
fix(chart): 技術指標選單/設定 portal 到 body，不再被面板蓋住（#39）

### DIFF
--- a/src/components/indicator-dialog.tsx
+++ b/src/components/indicator-dialog.tsx
@@ -14,6 +14,7 @@ import {
     X,
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
     CUSTOM_PREFIX,
     customType,
@@ -233,7 +234,10 @@ export function IndicatorDialog({
         );
     };
 
-    return (
+    // portal 到 body：面板（react-grid-item）有 transform，會把 fixed
+    // overlay 困在面板的 containing block / stacking context 裡 —
+    // 視窗溢出面板又被其他面板蓋住（issue #39）
+    return createPortal(
         <div
             className={styles.overlay}
             onMouseDown={(e) => {
@@ -343,7 +347,8 @@ export function IndicatorDialog({
                     onClose={() => setEditorFor(null)}
                 />
             )}
-        </div>
+        </div>,
+        document.body,
     );
 }
 
@@ -501,7 +506,8 @@ export function IndicatorSettingsModal({
         });
     };
 
-    return (
+    // 同 IndicatorDialog：portal 到 body 逃出面板的 transform 陷阱
+    return createPortal(
         <div
             className={styles.overlay}
             onMouseDown={(e) => {
@@ -857,6 +863,7 @@ export function IndicatorSettingsModal({
                     </div>
                 </div>
             </div>
-        </div>
+        </div>,
+        document.body,
     );
 }


### PR DESCRIPTION
## 問題（#39）

K 線圖面板縮矮後打開技術指標選擇視窗，視窗會溢出面板範圍、又會被其他面板蓋過去，底部的指標選不到。

## 根因

`IndicatorDialog` 與 `IndicatorSettingsModal` render 在面板子樹裡；react-grid-item 用 `transform` 定位，讓 `position: fixed` 的 overlay 的 containing block 變成面板本身、z-index 也被困在面板的 stacking context — 所以「fixed 全螢幕」的 modal 實際上跟著面板走、蓋不過鄰居面板。

## 修法

兩個 modal 都改用 `createPortal` 掛到 `document.body`。theme class 掛在 `documentElement` 上，portal 不會掉出 theme scope；React 事件 bubbling 行為不變。`CustomIndicatorEditor` 巢在 IndicatorDialog 內，一併受惠。

## 驗證

dev app 實測：面板縮矮後開指標選單 → 全視窗置中、蓋在所有面板之上；設定 modal（含圖上即時預覽 MA）同樣正常。`tsc -b`、vitest、vite build 全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)