### PR TITLE
fix(ticksize): FUT/OPT 級距改吃 server tick-bands，不再寫死表

### DIFF
--- a/src/components/flash-order.tsx
+++ b/src/components/flash-order.tsx
@@ -25,6 +25,7 @@ import type { ContractInfo } from '../lib/types/contract';
 import { ACTIVE_ORDER_STATUSES, type Action, type Trade } from '../lib/types/order';
 import type { Position } from '../lib/types/portfolio';
 import { fmtInt, fmtPrice, fmtSigned } from '../lib/utils/format';
+import { useTickBandsVersion } from '../lib/tick-bands';
 import { roundToTick, stepPrice } from '../lib/utils/ticksize';
 import * as styles from './flash-order.css';
 
@@ -252,6 +253,9 @@ export function FlashOrder({
     // limit-up/down. When one side is cut short by a limit, the other side
     // borrows the leftover rows so the window always stays full — the limit
     // price sticks to the top/bottom edge instead of leaving blank space.
+    // bandsVer：tick-bands 到貨時重算 — 盤後沒有行情跳動觸發時，
+    // 載入前用 fallback 格算出的 rows 才會被換成正確級距
+    const bandsVer = useTickBandsVersion();
     const rows = useMemo(() => {
         if (anchor === null) return [] as number[];
         // the anchor itself must stay inside the price limits
@@ -284,7 +288,7 @@ export function FlashOrder({
             center,
             ...downs.slice(0, nDown),
         ];
-    }, [anchor, rowCount, contract, limitUp, limitDown]);
+    }, [anchor, rowCount, contract, limitUp, limitDown, bandsVer]);
 
     const rowsRef = useRef(rows);
     rowsRef.current = rows;

--- a/src/lib/contracts-cache.ts
+++ b/src/lib/contracts-cache.ts
@@ -5,7 +5,19 @@
 import { useSyncExternalStore } from 'react';
 import { resolveContract, subscribeContractQuotes } from './shioaji';
 import { registerCodeAlias } from './stream';
+import { prefetchTickBands } from './tick-bands';
 import type { ContractInfo, SecurityType } from './types/contract';
+
+// 期權合約一進 cache 就預取級距表 — 面板首次渲染（要等行情快照）前
+// bands 已就緒，render 期的 lazy prefetch 只是最後防線
+function prefetchBands(c: ContractInfo) {
+    if (
+        (c.security_type === 'FUT' || c.security_type === 'OPT') &&
+        c.tick_rule
+    ) {
+        prefetchTickBands(c.tick_rule, c.security_type);
+    }
+}
 
 const cache = new Map<string, ContractInfo>();
 const pending = new Map<string, Promise<ContractInfo>>();
@@ -26,6 +38,7 @@ export function primeContract(contract: ContractInfo) {
     if (contract.target_code) {
         registerCodeAlias(contract.target_code, contract.code);
     }
+    prefetchBands(contract);
     emit();
 }
 
@@ -113,6 +126,7 @@ export async function ensureContract(
         if (contract.target_code) {
             registerCodeAlias(contract.target_code, contract.code);
         }
+        prefetchBands(contract);
         ensureQuoteSubscription(contract);
         emit();
         return contract;

--- a/src/lib/shioaji.ts
+++ b/src/lib/shioaji.ts
@@ -6,6 +6,7 @@ import type {
     ContractBase,
     ContractInfo,
     SecurityType,
+    TickBandsResponse,
 } from './types/contract';
 import type { Health } from './types/health';
 import type {
@@ -201,6 +202,15 @@ export function fetchContractInfo(code: string, securityType?: SecurityType) {
             security_type: securityType ?? undefined,
             region: 'TW',
         })}`,
+    );
+}
+
+// FUT/OPT 跳動級距表 — rule 名稱來自 contract info 的 tick_rule
+export function fetchTickBands(rule: string, securityType: 'FUT' | 'OPT') {
+    return apiGet<TickBandsResponse>(
+        `/api/v1/data/contracts/tick-bands/${encodeURIComponent(rule)}${contractQuery(
+            { security_type: securityType, region: 'TW' },
+        )}`,
     );
 }
 

--- a/src/lib/tick-bands.ts
+++ b/src/lib/tick-bands.ts
@@ -1,0 +1,55 @@
+// src/lib/tick-bands.ts — FUT/OPT 跳動級距（tick bands）快取
+//
+// 期權級距不寫死在程式裡（交易所規則會改，skill 紀律）：以 server 的
+// tick-bands API 為權威，按 tick_rule 名稱快取一次、全程同步查表。
+// 尚未載入時呼叫端 fallback 到 contract.tick（server 給的參考價位級距，
+// 在同一級距帶內正確）— localhost 取回是毫秒級，實務上首次渲染前就緒。
+
+import { fetchTickBands } from './shioaji';
+import type { TickBand } from './types/contract';
+
+const cache = new Map<string, TickBand[]>();
+const inflight = new Set<string>();
+
+// 同步查表：rule 已載入時回該價位（權利金）所在 band 的 tick
+export function bandTickFor(rule: string, price: number): number | undefined {
+    const bands = cache.get(rule);
+    if (!bands) return undefined;
+    for (const b of bands) {
+        if (price >= b.min && (b.max === null || price < b.max)) return b.tick;
+    }
+    return undefined;
+}
+
+// 冪等預取：未快取的 rule 發一次 API，失敗允許之後重試
+export function prefetchTickBands(
+    rule: string,
+    securityType: 'FUT' | 'OPT',
+): void {
+    if (cache.has(rule) || inflight.has(rule)) return;
+    inflight.add(rule);
+    try {
+        fetchTickBands(rule, securityType)
+            .then((res) => {
+                cache.set(rule, res.bands);
+            })
+            .catch(() => {
+                // 失敗不快取 — 下次呼叫重試；期間吃 contract.tick fallback
+            })
+            .finally(() => {
+                inflight.delete(rule);
+            });
+    } catch {
+        inflight.delete(rule);
+    }
+}
+
+// 測試用：直接灌表／清空（正式路徑一律走 prefetch）
+export function setTickBands(rule: string, bands: TickBand[]) {
+    cache.set(rule, bands);
+}
+
+export function clearTickBands() {
+    cache.clear();
+    inflight.clear();
+}

--- a/src/lib/tick-bands.ts
+++ b/src/lib/tick-bands.ts
@@ -5,11 +5,21 @@
 // 尚未載入時呼叫端 fallback 到 contract.tick（server 給的參考價位級距，
 // 在同一級距帶內正確）— localhost 取回是毫秒級，實務上首次渲染前就緒。
 
+import { useSyncExternalStore } from 'react';
 import { fetchTickBands } from './shioaji';
 import type { TickBand } from './types/contract';
 
 const cache = new Map<string, TickBand[]>();
 const inflight = new Set<string>();
+// bands 到貨要讓依 tick 計算的 memo（閃電下單 rows）失效 — 盤後沒有
+// 行情跳動觸發 re-render 時，載入完成前算出的 fallback 格才會被換掉
+let version = 0;
+const listeners = new Set<() => void>();
+
+function bump() {
+    version++;
+    listeners.forEach((l) => l());
+}
 
 // 同步查表：rule 已載入時回該價位（權利金）所在 band 的 tick
 export function bandTickFor(rule: string, price: number): number | undefined {
@@ -32,6 +42,7 @@ export function prefetchTickBands(
         fetchTickBands(rule, securityType)
             .then((res) => {
                 cache.set(rule, res.bands);
+                bump();
             })
             .catch(() => {
                 // 失敗不快取 — 下次呼叫重試；期間吃 contract.tick fallback
@@ -44,12 +55,25 @@ export function prefetchTickBands(
     }
 }
 
+// 依 tick 計算 memo 的元件把這個 version 放進 deps — bands 到貨即重算
+export function useTickBandsVersion(): number {
+    return useSyncExternalStore(
+        (l) => {
+            listeners.add(l);
+            return () => listeners.delete(l);
+        },
+        () => version,
+    );
+}
+
 // 測試用：直接灌表／清空（正式路徑一律走 prefetch）
 export function setTickBands(rule: string, bands: TickBand[]) {
     cache.set(rule, bands);
+    bump();
 }
 
 export function clearTickBands() {
     cache.clear();
     inflight.clear();
+    bump();
 }

--- a/src/lib/types/contract.ts
+++ b/src/lib/types/contract.ts
@@ -71,3 +71,19 @@ export interface ContractInfo extends Contract {
     // 走組合行情路徑，且不可用一般下單面板下單
     combo?: ContractComboMeta;
 }
+
+// FUT/OPT 跳動級距（server tick-bands API）；max=null 為最上層 band
+export interface TickBand {
+    min: number;
+    max: number | null;
+    tick: number;
+}
+
+export interface TickBandsResponse {
+    region: string;
+    security_type: SecurityType;
+    rule: string;
+    // 'price'（期貨依價格）或 'premium'（選擇權依權利金）— 查表語意相同
+    basis: string;
+    bands: TickBand[];
+}

--- a/src/lib/utils/ticksize.test.ts
+++ b/src/lib/utils/ticksize.test.ts
@@ -1,9 +1,30 @@
-// 個股期跳動級距回歸（issue #38：閃電下單階梯只出整數價位）—
-// tick_rule=tw_stock_fut_price_band 的期貨要照現股級距跳 0.5 等。
+// FUT/OPT 級距回歸（issue #38 系列）— 級距以 server tick-bands 為權威：
+// 個股期 500–2500 元跳 1、2500 以上才跳 5（非現股表的 1000 分界），
+// TXO 權利金 50–500 點跳 1。bands 未載入時 fallback contract.tick。
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearTickBands, setTickBands } from '../tick-bands';
 import type { ContractBase, ContractInfo } from '../types/contract';
 import { roundToTick, stepPrice, tickSizeFor } from './ticksize';
+
+// server 實際回應（/data/contracts/tick-bands/tw_stock_fut_price_band）
+const STOCK_FUT_BANDS = [
+    { min: 0, max: 10, tick: 0.01 },
+    { min: 10, max: 50, tick: 0.05 },
+    { min: 50, max: 100, tick: 0.1 },
+    { min: 100, max: 500, tick: 0.5 },
+    { min: 500, max: 2500, tick: 1 },
+    { min: 2500, max: null, tick: 5 },
+];
+
+// server 實際回應（tw_txo_premium_band）
+const TXO_BANDS = [
+    { min: 0, max: 10, tick: 0.1 },
+    { min: 10, max: 50, tick: 0.5 },
+    { min: 50, max: 500, tick: 1 },
+    { min: 500, max: 1000, tick: 5 },
+    { min: 1000, max: null, tick: 10 },
+];
 
 // issue #38 的實際合約資料（聯電期貨 202609）
 const ccfi6 = {
@@ -14,8 +35,6 @@ const ccfi6 = {
     tick: 0.5,
     tick_rule: 'tw_stock_fut_price_band',
     underlying_kind: 'S',
-    spec_kind: 'stock_fut',
-    underlying_code: '2303',
 } as ContractBase & Partial<ContractInfo>;
 
 const txf = {
@@ -27,57 +46,51 @@ const txf = {
     underlying_kind: 'I',
 } as ContractBase & Partial<ContractInfo>;
 
-describe('tickSizeFor — futures', () => {
-    it('個股期 tick_rule=tw_stock_fut_price_band 走現股級距', () => {
-        expect(tickSizeFor(ccfi6, 130)).toBe(0.5); // 100–500 band
-        expect(tickSizeFor(ccfi6, 99)).toBe(0.1);
+const txo = {
+    exchange: 'TAIFEX',
+    code: 'TXO21800I6',
+    security_type: 'OPT',
+    target_code: null,
+    tick: 10,
+    tick_rule: 'tw_txo_premium_band',
+} as ContractBase & Partial<ContractInfo>;
+
+beforeEach(() => {
+    clearTickBands();
+    setTickBands('tw_stock_fut_price_band', STOCK_FUT_BANDS);
+    setTickBands('tw_txo_premium_band', TXO_BANDS);
+});
+
+describe('tickSizeFor — 個股期 tick-bands', () => {
+    it('各級距帶照 server 表（含 2500 分界，非現股表的 1000）', () => {
+        expect(tickSizeFor(ccfi6, 5)).toBe(0.01);
         expect(tickSizeFor(ccfi6, 45)).toBe(0.05);
+        expect(tickSizeFor(ccfi6, 99)).toBe(0.1);
+        expect(tickSizeFor(ccfi6, 130)).toBe(0.5);
         expect(tickSizeFor(ccfi6, 600)).toBe(1);
-        expect(tickSizeFor(ccfi6, 1200)).toBe(5);
+        expect(tickSizeFor(ccfi6, 1200)).toBe(1); // 現股表在此是 5 — 個股期是 1
+        expect(tickSizeFor(ccfi6, 2400)).toBe(1);
+        expect(tickSizeFor(ccfi6, 2600)).toBe(5);
     });
 
-    it('指數期維持 1 點', () => {
-        expect(tickSizeFor(txf, 24000)).toBe(1);
-    });
-
-    it('缺 tick_rule 的舊資料用 underlying_kind=S 判別個股期', () => {
-        const legacy = { ...ccfi6, tick_rule: undefined, tick: undefined };
-        expect(tickSizeFor(legacy, 130)).toBe(0.5);
-    });
-
-    it('缺 tick_rule 也缺 underlying_kind 時 spec_kind=stock_fut 同樣判別', () => {
-        const legacy = {
-            ...ccfi6,
-            tick_rule: undefined,
-            tick: undefined,
-            underlying_kind: undefined,
-        };
-        expect(tickSizeFor(legacy, 130)).toBe(0.5);
+    it('bands 未載入 fallback 到 server 給的 tick', () => {
+        clearTickBands();
+        expect(tickSizeFor(ccfi6, 130)).toBe(0.5);
     });
 
     it('server tick 為字串時照樣可用（1.7.x 數值字串化容錯）', () => {
+        clearTickBands();
         const stringTick = {
-            ...txf,
-            code: 'ZFFR1',
-            underlying_kind: undefined,
-            tick: '0.25' as unknown as number,
-        };
-        expect(tickSizeFor(stringTick, 300)).toBe(0.25);
-    });
-
-    it('ETF 期不套現股級距，用 server 提供的 tick', () => {
-        const etfFut = {
             ...ccfi6,
-            code: 'NYFR1',
-            tick_rule: undefined,
-            spec_kind: 'etf_fut',
-            underlying_code: '0050',
-            tick: 0.05,
+            tick: '0.5' as unknown as number,
         };
-        expect(tickSizeFor(etfFut, 60)).toBe(0.05);
+        expect(tickSizeFor(stringTick, 130)).toBe(0.5);
     });
 
-    it('沒有任何 metadata 的期貨 fallback 到 1 點', () => {
+    it('無任何 metadata 的舊資料：underlying_kind=S 用現股表、其餘 1 點', () => {
+        clearTickBands();
+        const legacy = { ...ccfi6, tick_rule: undefined, tick: undefined };
+        expect(tickSizeFor(legacy, 130)).toBe(0.5);
         const bare: ContractBase = {
             exchange: 'TAIFEX',
             code: 'TXFI6',
@@ -88,6 +101,27 @@ describe('tickSizeFor — futures', () => {
     });
 });
 
+describe('tickSizeFor — 指數期與選擇權', () => {
+    it('fixed basis 指數期吃 tick=1', () => {
+        expect(tickSizeFor(txf, 24000)).toBe(1);
+    });
+
+    it('TXO premium band 照 server 表（修正舊寫死的 >=10→1）', () => {
+        expect(tickSizeFor(txo, 5)).toBe(0.1);
+        expect(tickSizeFor(txo, 30)).toBe(0.5); // 舊邏輯錯給 1
+        expect(tickSizeFor(txo, 200)).toBe(1);
+        expect(tickSizeFor(txo, 600)).toBe(5);
+        expect(tickSizeFor(txo, 1500)).toBe(10);
+    });
+
+    it('OPT 無 metadata 舊資料維持舊 fallback', () => {
+        clearTickBands();
+        const legacyOpt = { ...txo, tick_rule: undefined, tick: undefined };
+        expect(tickSizeFor(legacyOpt, 30)).toBe(1);
+        expect(tickSizeFor(legacyOpt, 5)).toBe(0.1);
+    });
+});
+
 describe('stepPrice / roundToTick — 個股期', () => {
     it('階梯以 0.5 遞增（issue #38 預期行為）', () => {
         expect(stepPrice(ccfi6, 118, 1)).toBe(118.5);
@@ -95,10 +129,13 @@ describe('stepPrice / roundToTick — 個股期', () => {
         expect(stepPrice(ccfi6, 118, -1)).toBe(117.5);
     });
 
-    it('跨 100 元級距邊界換 tick', () => {
+    it('跨級距邊界換 tick（100 與 2500 分界）', () => {
         expect(stepPrice(ccfi6, 99.9, 1)).toBe(100);
         expect(stepPrice(ccfi6, 100, 1)).toBe(100.5);
         expect(stepPrice(ccfi6, 100, -1)).toBe(99.9);
+        expect(stepPrice(ccfi6, 2499, 1)).toBe(2500);
+        expect(stepPrice(ccfi6, 2500, 1)).toBe(2505);
+        expect(stepPrice(ccfi6, 2500, -1)).toBe(2499);
     });
 
     it('roundToTick 對齊 0.5 級距', () => {
@@ -116,7 +153,7 @@ describe('現股 / ETF 級距不受影響', () => {
     } as ContractBase;
     const etf = { ...stk, code: '0050' };
 
-    it('現股級距照舊', () => {
+    it('現股級距照舊（現股 1000 以上跳 5）', () => {
         expect(tickSizeFor(stk, 1200)).toBe(5);
         expect(tickSizeFor(stk, 95)).toBe(0.1);
     });

--- a/src/lib/utils/ticksize.ts
+++ b/src/lib/utils/ticksize.ts
@@ -1,22 +1,19 @@
-// src/lib/utils/ticksize.ts — TW market tick size tables
+// src/lib/utils/ticksize.ts — TW market tick sizes
+//
+// 期權（FUT/OPT）級距不寫死：以 server tick-bands API 為權威（skill 紀律
+// 「Do not hard-code futures tick sizes」）— tick_rule 命名的級距表由
+// lib/tick-bands 快取，尚未載入時 fallback 到 contract.tick。現貨（STK/
+// ETF）交易所級距表 server 不提供，維持本地表。
 
+import { bandTickFor, prefetchTickBands } from '../tick-bands';
 import type { ContractBase, ContractInfo } from '../types/contract';
 
-// 有 info metadata（TAIFEX 1.7 的 tick_rule/spec_kind 等）時能選對級距表；
-// 仍接受只有 ContractBase 的呼叫端（metadata 缺席 → 走舊 fallback）
+// 有 info metadata（tick_rule/tick）時走 server 級距；仍接受只有
+// ContractBase 的呼叫端（metadata 缺席 → 走舊 fallback）
 type TickContract = ContractBase &
-    Partial<
-        Pick<
-            ContractInfo,
-            | 'tick_rule'
-            | 'tick'
-            | 'underlying_kind'
-            | 'spec_kind'
-            | 'underlying_code'
-        >
-    >;
+    Partial<Pick<ContractInfo, 'tick_rule' | 'tick' | 'underlying_kind'>>;
 
-// TWSE/TPEX equities；個股期同級距（TAIFEX tw_stock_fut_price_band）
+// TWSE/TPEX equities
 function stockTick(price: number): number {
     if (price < 10) return 0.01;
     if (price < 50) return 0.05;
@@ -32,28 +29,23 @@ function etfTick(price: number): number {
 }
 
 export function tickSizeFor(contract: TickContract, price: number): number {
-    if (contract.security_type === 'FUT') {
-        // 個股期跳動跟現股同級距，以 server 的 tick_rule 為準；沒有
-        // metadata 的舊資料用 underlying_kind 'S' 判別，但要排除 ETF 期
-        // （級距不同，交給下面的 server tick fallback）
-        const isEtfFut =
-            contract.spec_kind === 'etf_fut' ||
-            (contract.underlying_code ?? '').startsWith('00');
-        if (
-            contract.tick_rule === 'tw_stock_fut_price_band' ||
-            (!contract.tick_rule &&
-                !isEtfFut &&
-                (contract.spec_kind === 'stock_fut' ||
-                    contract.underlying_kind === 'S'))
-        ) {
-            return stockTick(price);
+    const st = contract.security_type;
+    if (st === 'FUT' || st === 'OPT') {
+        // banded 商品（個股期 tw_stock_fut_price_band、TXO premium band
+        // 等）：查 server 級距表；未載入先預取（冪等），本輪先走 fallback
+        if (contract.tick_rule) {
+            prefetchTickBands(contract.tick_rule, st);
+            const bt = bandTickFor(contract.tick_rule, price);
+            if (bt !== undefined) return bt;
         }
-        // 非 1 點跳動的其他期貨（ETF 期等）以 server 提供的 tick 為準
+        // fixed basis（指數期等）或 bands 尚未載入：server 給的 tick
+        //（banded 商品的 tick 為參考價所在 band，帶內正確）
         const t = Number(contract.tick);
         if (Number.isFinite(t) && t > 0) return t;
-        return 1; // TXF/MXF/TMF index futures
+        // 無 metadata 的舊資料最後防線
+        if (st === 'OPT') return price >= 10 ? 1 : 0.1;
+        return contract.underlying_kind === 'S' ? stockTick(price) : 1;
     }
-    if (contract.security_type === 'OPT') return price >= 10 ? 1 : 0.1;
     if (contract.code.startsWith('00')) return etfTick(price);
     return stockTick(price);
 }


### PR DESCRIPTION
## 動機

PR #41 把個股期級距寫死成現股表 — 違反 shioaji skill 紀律（**Do not hard-code futures tick sizes. Use `tick_rule`/`tick_bands()`**），而且表是錯的：

- server 權威 band（`/data/contracts/tick-bands/tw_stock_fut_price_band`）：**500–2500 元跳 1、2500 以上才跳 5** — 分界是 2500，不是現股表的 1000。寫死表在 1000–2500 元區間會跳 5（應跳 1）。
- 順帶修正：舊 OPT 寫死 `>=10→1` 對 TXO premium band 也是錯的（10–50 點應 0.5、500–1000 應 5、1000 以上 10）。

## 修法

- 新增 `lib/tick-bands.ts`：按 `tick_rule` 名稱快取 server tick-bands（冪等預取、失敗可重試、同步查表）。
- `tickSizeFor`：FUT/OPT 有 `tick_rule` → 查 band 表；未載入的一輪 fallback `contract.tick`（server 給的參考價所在帶級距，帶內正確，localhost 毫秒級就緒）；`fixed` basis（指數期）直接吃 `tick`；無 metadata 舊資料維持原 fallback。現貨 STK/ETF 維持本地表（server 不提供現貨 bands）。
- 測試 fixture 改用 server 實際回應，覆蓋 2500 分界、TXO band、字串 tick 容錯、fallback 鏈。

## 驗證

- `tsc -b`＋126 tests 全綠。
- dev app 實測：載入 CCFI6 自動發 tick-bands 請求（200），階梯照 0.5 遞增。

🤖 Generated with [Claude Code](https://claude.com/claude-code)