### PR TITLE
fix(hotkeys): modal Esc 走 stack＋preventDefault，不誤武裝 Esc-Esc 刪單

### DIFF
--- a/src/components/custom-indicator-editor.tsx
+++ b/src/components/custom-indicator-editor.tsx
@@ -4,6 +4,7 @@
 
 import { HelpCircle, Plus, Trash2, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { useEscClose } from '../hooks/use-esc-close';
 import {
     CUSTOM_PALETTE,
     deleteCustom,
@@ -84,14 +85,7 @@ export function CustomIndicatorEditor({
     );
     const busyRef = useRef(false);
 
-    useEffect(() => {
-        const onKey = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') onClose();
-        };
-        window.addEventListener('keydown', onKey);
-        return () => window.removeEventListener('keydown', onKey);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    useEscClose(onClose);
 
     const paramDefaults = (list: ParamDef[]) => {
         const p: Record<string, number> = {};

--- a/src/components/custom-indicator-editor.tsx
+++ b/src/components/custom-indicator-editor.tsx
@@ -3,7 +3,7 @@
 // 驗證（2 秒逾時擋無窮迴圈）並自動偵測 plot()/hline() 的輸出。
 
 import { HelpCircle, Plus, Trash2, X } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useEscClose } from '../hooks/use-esc-close';
 import {
     CUSTOM_PALETTE,

--- a/src/components/indicator-dialog.tsx
+++ b/src/components/indicator-dialog.tsx
@@ -14,6 +14,7 @@ import {
     X,
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEscClose } from '../hooks/use-esc-close';
 import { createPortal } from 'react-dom';
 import {
     CUSTOM_PREFIX,
@@ -106,13 +107,8 @@ export function IndicatorDialog({
 
     useEffect(() => {
         inputRef.current?.focus();
-        const onKey = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') onClose();
-        };
-        window.addEventListener('keydown', onKey);
-        return () => window.removeEventListener('keydown', onKey);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+    useEscClose(onClose);
 
     const toggleFav = (type: string) => {
         setFavs((prev) => {
@@ -473,14 +469,7 @@ export function IndicatorSettingsModal({
     const [defaultsOpen, setDefaultsOpen] = useState(false);
     const [savedTip, setSavedTip] = useState(false);
 
-    useEffect(() => {
-        const onKey = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') onCancel();
-        };
-        window.addEventListener('keydown', onKey);
-        return () => window.removeEventListener('keydown', onKey);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    useEscClose(onCancel);
 
     if (!def) return null;
 

--- a/src/hooks/use-esc-close.test.ts
+++ b/src/hooks/use-esc-close.test.ts
@@ -1,0 +1,114 @@
+// modal Esc stack 語意：只關最上層、一律 preventDefault（Esc-Esc 全刪單
+// 防護依 defaultPrevented 判斷）、空栈時卸掉 window listener。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { escStackDepth, pushEscHandler } from './use-esc-close';
+
+type Listener = (e: KeyboardEvent) => void;
+
+let captureListeners: Listener[];
+let cleanups: (() => void)[];
+
+// 測試內一律經 push 註冊 — afterEach 統一出栈（不能用 dispatch 清栈：
+// 不自清的 handler 會讓 while 迴圈永不見底）
+function push(h: () => void) {
+    const c = pushEscHandler(h);
+    cleanups.push(c);
+    return c;
+}
+
+function fakeEsc() {
+    return {
+        key: 'Escape',
+        preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent & { preventDefault: ReturnType<typeof vi.fn> };
+}
+
+function dispatchEsc() {
+    const e = fakeEsc();
+    for (const l of [...captureListeners]) l(e);
+    return e;
+}
+
+beforeEach(() => {
+    captureListeners = [];
+    cleanups = [];
+    vi.stubGlobal('window', {
+        addEventListener: (
+            type: string,
+            l: Listener,
+            capture?: boolean,
+        ) => {
+            if (type === 'keydown' && capture) captureListeners.push(l);
+        },
+        removeEventListener: (
+            type: string,
+            l: Listener,
+            capture?: boolean,
+        ) => {
+            if (type === 'keydown' && capture) {
+                captureListeners = captureListeners.filter((x) => x !== l);
+            }
+        },
+    });
+});
+
+afterEach(() => {
+    for (const c of cleanups) c(); // 重複 cleanup 為 no-op
+    expect(escStackDepth()).toBe(0);
+    vi.unstubAllGlobals();
+});
+
+describe('pushEscHandler', () => {
+    it('只有最上層 handler 被呼叫，且 preventDefault', () => {
+        const a = vi.fn();
+        const b = vi.fn();
+        push(a);
+        push(b);
+        const e = dispatchEsc();
+        expect(b).toHaveBeenCalledTimes(1);
+        expect(a).not.toHaveBeenCalled();
+        expect(e.preventDefault).toHaveBeenCalled();
+    });
+
+    it('上層卸除後 Esc 落到下一層', () => {
+        const a = vi.fn();
+        const b = vi.fn();
+        push(a);
+        const cleanupB = push(b);
+        cleanupB();
+        dispatchEsc();
+        expect(a).toHaveBeenCalledTimes(1);
+        expect(b).not.toHaveBeenCalled();
+    });
+
+    it('空栈時 window listener 卸載、Esc 不再被攔（刪單熱鍵可運作）', () => {
+        const a = vi.fn();
+        const cleanup = push(a);
+        expect(captureListeners.length).toBe(1);
+        cleanup();
+        expect(captureListeners.length).toBe(0);
+    });
+
+    it('handler 觸發關閉（呼叫端 unmount → cleanup）後下一下 Esc 給下層', () => {
+        // 模擬真實流程：Esc 關最上層 modal，其 effect cleanup 出栈
+        const closedOrder: string[] = [];
+        const cleanupA: (() => void)[] = [];
+        cleanupA.push(
+            push(() => {
+                closedOrder.push('dialog');
+                cleanupA[0]!();
+            }),
+        );
+        const cleanupB: (() => void)[] = [];
+        cleanupB.push(
+            push(() => {
+                closedOrder.push('editor');
+                cleanupB[0]!();
+            }),
+        );
+        dispatchEsc();
+        dispatchEsc();
+        expect(closedOrder).toEqual(['editor', 'dialog']);
+    });
+});

--- a/src/hooks/use-esc-close.ts
+++ b/src/hooks/use-esc-close.ts
@@ -16,6 +16,11 @@ let listener: ((e: KeyboardEvent) => void) | null = null;
 
 function onKeydown(e: KeyboardEvent) {
     if (e.key !== 'Escape' || stack.length === 0) return;
+    // 按住 Esc 的 OS 連發不往下層級聯（一次按鍵只關一層）
+    if (e.repeat) {
+        e.preventDefault();
+        return;
+    }
     e.preventDefault();
     stack[stack.length - 1]!();
 }

--- a/src/hooks/use-esc-close.ts
+++ b/src/hooks/use-esc-close.ts
@@ -1,0 +1,52 @@
+// src/hooks/use-esc-close.ts — modal 的 Esc 關閉（modal stack）
+//
+// 兩個保證：
+// 1. 只關最上層 — 疊層 modal（指標選單上再開自訂指標編輯器）按一次
+//    Esc 只收最上面那層，不會連鎖全關（未存的編輯內容不會被帶走）。
+// 2. 一律 preventDefault — use-hotkeys 的 Esc-Esc 全刪單（escCancelAll）
+//    以 e.defaultPrevented 判斷「這下 Esc 已被 dialog 吃掉」，關閉
+//    dialog 的那一下絕不能武裝刪單視窗（settings-dialog 同一模式）。
+
+import { useEffect, useRef } from 'react';
+
+type Handler = () => void;
+
+const stack: Handler[] = [];
+let listener: ((e: KeyboardEvent) => void) | null = null;
+
+function onKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Escape' || stack.length === 0) return;
+    e.preventDefault();
+    stack[stack.length - 1]!();
+}
+
+// exported for tests（元件一律走 useEscClose）
+export function pushEscHandler(h: Handler): () => void {
+    if (!listener) {
+        listener = onKeydown;
+        // capture：搶在 use-hotkeys 的 bubble listener 之前標記
+        window.addEventListener('keydown', listener, true);
+    }
+    stack.push(h);
+    return () => {
+        const i = stack.lastIndexOf(h);
+        if (i >= 0) stack.splice(i, 1);
+        if (stack.length === 0 && listener) {
+            window.removeEventListener('keydown', listener, true);
+            listener = null;
+        }
+    };
+}
+
+// mount 即入栈（modal 都是條件渲染，mount = 開啟）；close callback
+// 走 ref，父層 re-render 換新 closure 不用重掛
+export function useEscClose(onClose: Handler) {
+    const ref = useRef(onClose);
+    ref.current = onClose;
+    useEffect(() => pushEscHandler(() => ref.current()), []);
+}
+
+// 測試用
+export function escStackDepth() {
+    return stack.length;
+}


### PR DESCRIPTION
## 問題（PR #42 review 發現的 pre-existing）

指標選單、指標設定、自訂指標編輯器的 Esc 關閉是各自的 window bubble listener、不 preventDefault：

1. **escCancelAll 誤武裝**：use-hotkeys 依 `e.defaultPrevented` 跳過「dialog 已吃掉的 Esc」；這三個 dialog 不標記，關窗那下 Esc 會武裝全刪單視窗，0.6 秒內再按一次就全刪單（settings-dialog 早已用 capture+preventDefault 正確模式）。
2. **疊層連鎖關閉**：指標選單上開自訂指標編輯器時，一下 Esc 兩層 listener 都觸發 — 編輯器連同外層一起關，未存的指標程式碼遺失。

## 修法

新增 `hooks/use-esc-close`：單一 window **capture** listener＋modal stack — Esc 只關最上層、一律 preventDefault；三個 dialog 改用 `useEscClose`。settings-dialog 行為已正確、不動。

## 驗證

- 4 條 stack 語意單元測試（最上層優先、逐層關閉、空栈卸 listener、preventDefault）；`tsc -b`＋130 tests 全綠。
- dev app 實測：指標選單→建立自訂指標→Esc 只關編輯器、選單留存；再 Esc 關選單。

補充：flash-order 的 armed-Esc 解除同樣不 preventDefault（解除下單模式的 Esc 也會武裝刪單視窗）— 語意上「解除」與「關窗」不同，是否也要吃掉 Esc 留待決定，本 PR 不動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)