### PR TITLE
docs: clarify development branch rebase policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent startup
+
+Before every development task in this repository, read these files in full:
+
+1. [`docs/DEV.md`](docs/DEV.md) — branching, worktrees, review, CI, and quality rules.
+2. [`docs/RELEASE.md`](docs/RELEASE.md) — release ownership, versioning, tagging, and verification.
+
+Read them again at the start of each task because the workflow may change. Treat
+them as authoritative before editing code, documentation, configuration, Git
+history, or release state.

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -10,8 +10,9 @@
    所有變更（含文件、發佈 notes）一律走 PR。
 2. **main 永遠是綠的、永遠可發佈** — 任何時刻都可能對 main 打 tag 出版
    （見 [RELEASE.md](RELEASE.md)），merge 進 main 等同宣告「可出貨」。
-3. **merge 一律 merge commit（`--merge`）** — 禁 squash / rebase。
-   保留原 commit SHA 是發佈追溯與 tag 祖先關係的前提。
+3. **PR 合進 main 一律 merge commit（`--merge`）** — 禁 squash merge／
+   rebase merge。保留功能分支 commit SHA 是發佈追溯與 tag 祖先關係的
+   前提；開發分支同步 main 的 rebase 規則見下節。
 
 ## 分支與 worktree
 
@@ -27,6 +28,21 @@
   ```
 
   agent 開發使用內建 worktree 機制，效果等同。
+
+### 開發分支同步 main
+
+- 尚未推送、只有單一開發者使用、且未被其他 repo／分支以 SHA 引用的
+  短期開發分支，應定期同步最新 main：
+
+  ```bash
+  git fetch origin
+  git rebase origin/main
+  ```
+
+- 分支一旦已推送共享、開啟 PR／進入 review，或被跨 repo pin 指向，
+  就必須保留既有 SHA，改用 `git merge origin/main` 同步；不得 force-push
+  重寫已共享歷史。
+- PR 最終仍以 merge commit 合進 main；開發分支曾 rebase 不改變這項規則。
 
 ## PR 與 review
 


### PR DESCRIPTION
## Summary
- clarify when short-lived development branches should rebase the latest main
- require shared, reviewed, or SHA-pinned branches to merge main instead
- add AGENTS.md requiring docs/DEV.md and docs/RELEASE.md review before every task

## Validation
- git diff --check
- documentation-only change