### PR TITLE
fix(market): recover stalled index bootstrap queries

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
-import { shouldProxyAgentHarnessMutation } from './api';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { apiPost, shouldProxyAgentHarnessMutation } from './api';
+
+afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+});
 
 describe('agent harness mutation routing', () => {
     it('keeps normal UI orders on the direct HTTP path while disabled', () => {
@@ -34,5 +39,52 @@ describe('agent harness mutation routing', () => {
                 '/api/v1/order/place_order',
             ),
         ).toBe(false);
+    });
+});
+
+describe('apiPost timeout', () => {
+    it('aborts a stalled opt-in request', async () => {
+        vi.useFakeTimers();
+        vi.stubGlobal(
+            'fetch',
+            vi.fn((_url: string, init?: RequestInit) =>
+                new Promise<Response>((_resolve, reject) => {
+                    init?.signal?.addEventListener('abort', () =>
+                        reject(init.signal?.reason),
+                    );
+                }),
+            ),
+        );
+
+        const request = apiPost('/api/v1/data/index_components', {}, {
+            timeoutMs: 5_000,
+        });
+        const rejected = expect(request).rejects.toBeInstanceOf(Error);
+        await vi.advanceTimersByTimeAsync(5_000);
+        await rejected;
+    });
+
+    it('clears the timer after success instead of emitting a late abort', async () => {
+        vi.useFakeTimers();
+        let signal: AbortSignal | null | undefined;
+        vi.stubGlobal(
+            'fetch',
+            vi.fn((_url: string, init?: RequestInit) => {
+                signal = init?.signal;
+                return Promise.resolve(
+                    new Response('{}', {
+                        status: 200,
+                        headers: { 'Content-Type': 'application/json' },
+                    }),
+                );
+            }),
+        );
+
+        await apiPost('/api/v1/data/index_components', {}, {
+            timeoutMs: 5_000,
+        });
+        await vi.advanceTimersByTimeAsync(5_000);
+
+        expect(signal?.aborted).toBe(false);
     });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -50,6 +50,23 @@ async function doFetch(url: string, init?: RequestInit): Promise<Response> {
     return fetch(url, init);
 }
 
+async function doFetchWithTimeout(
+    url: string,
+    init: RequestInit,
+    timeoutMs?: number,
+): Promise<Response> {
+    if (!timeoutMs) return doFetch(url, init);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+        return await doFetch(url, { ...init, signal: controller.signal });
+    } finally {
+        // Tauri plugin-http forwards late aborts to Rust. Clear the timer once
+        // the request settles so it cannot cancel an already-freed resource.
+        clearTimeout(timer);
+    }
+}
+
 // shioaji errors come back as JSON: {"code":400,"message":"...","details":...}
 // surface that message instead of a bare "400 Bad Request" — the message is
 // what tells you it's CA / unsigned account / bad params (issue #1 support)
@@ -134,16 +151,17 @@ export async function apiPost<T>(
         if (!res.ok) await throwApiError(res);
         return res.json() as Promise<T>;
     }
-    const res = await doFetch(base() + path, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
+    const res = await doFetchWithTimeout(
+        base() + path,
+        {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        },
         // opt-in only — order paths must never abort an in-flight request
         // (an aborted POST tells us nothing about whether it was executed)
-        signal: opts?.timeoutMs
-            ? AbortSignal.timeout(opts.timeoutMs)
-            : undefined,
-    });
+        opts?.timeoutMs,
+    );
     if (!res.ok) await throwApiError(res);
     return res.json() as Promise<T>;
 }

--- a/src/lib/index-components.test.ts
+++ b/src/lib/index-components.test.ts
@@ -1,13 +1,14 @@
 // index-components 純函式測試 — payload 取自 2026-08-28 對 1.7.4
 // dev server 的實測樣本（wire decimal 一律字串）
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     parseIcEvent,
     projectFromSnapshot,
     projectionKey,
     type RawIndexComponentsSnapshot,
 } from './index-components';
+import { fetchIndexComponents } from './shioaji';
 import type { IcProjection } from './types/market';
 
 const P25: IcProjection = {
@@ -17,6 +18,33 @@ const P25: IcProjection = {
     order: 'positive_desc',
     limit: 25,
 };
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('index_components 建底查詢', () => {
+    it('帶逾時訊號，避免 server 切換時永久停在 pending', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(snapshot()), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        await fetchIndexComponents({
+            security_type: 'IND',
+            region: 'TW',
+            exchange: 'TSE',
+            code: 'IX0001',
+            target_code: null,
+        });
+
+        const init = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
+    });
+});
 
 describe('projectionKey', () => {
     it('對同一投影產生穩定 key，含群組後綴', () => {

--- a/src/lib/shioaji.ts
+++ b/src/lib/shioaji.ts
@@ -667,9 +667,14 @@ export function unsubscribeIndexComponents(
 // index_components 權威建底查詢 — 呼叫紀律見 docs/adr/0001：
 // 僅限首次與日切，429（日額度）不得重試，503（暖機）可退避重試
 export function fetchIndexComponents<T>(contract: ContractBase) {
-    return apiPost<T>('/api/v1/data/index_components', {
-        contract: contractKey(contract),
-    });
+    return apiPost<T>(
+        '/api/v1/data/index_components',
+        { contract: contractKey(contract) },
+        // Panels mount while desktop boot may still replace an incompatible
+        // sidecar. A request caught on the retiring process can otherwise
+        // remain pending forever and prevent the store's retry loop.
+        { timeoutMs: 5_000 },
+    );
 }
 
 export function scannerSubscriptionBody(


### PR DESCRIPTION
## 問題

市場脈動與產業全景會在即時 SSE 已正常後，仍停留在等待建底資料。`v0.1.43` 已有 `index_components` 首次 query，且該模組到 `v0.1.45` 未直接變更；但 v0.1.45 啟動流程可能在面板送出 query 後替換不相容 sidecar。落在 retiring process 的 plugin-http 請求可能永久 pending，阻止既有 retry loop。

## 修正

- `index_components` 唯讀建底 POST 增加 5 秒 timeout
- timeout 後由既有 2/4/8/15 秒退避機制重試
- 不影響 order mutation；交易請求仍不設定 timeout
- 新增回歸測試，確認建底請求一定帶 AbortSignal

## 驗證

- `npm test`: 19 files, 172 tests passed
- `npm run build`: passed
- `git diff --check`: passed
- 實測 server 相同 query 約 0.22 秒回傳完整盤前 snapshot
- `@tauri-apps/plugin-http` 會將 AbortSignal 傳到 Rust `fetch_cancel`