### PR TITLE
test(agent): add backward-compatible onboarding test prerequisites

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,10 @@
         "@types/node": "^25.9.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/react-test-renderer": "19.1.0",
         "@vanilla-extract/vite-plugin": "^5.2.2",
         "@vitejs/plugin-react": "^6.0.1",
+        "react-test-renderer": "19.2.7",
         "typescript": "~5.9.3",
         "vite": "^8.0.1",
         "vitest": "^4.1.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,12 +87,18 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@types/react-test-renderer':
+        specifier: 19.1.0
+        version: 19.1.0
       '@vanilla-extract/vite-plugin':
         specifier: ^5.2.2
         version: 5.2.2(@types/node@25.9.2)(esbuild@0.28.0)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0))
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0))
+      react-test-renderer:
+        specifier: 19.2.7
+        version: 19.2.7(react@19.2.7)
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -635,6 +641,9 @@ packages:
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react-test-renderer@19.1.0':
+    resolution: {integrity: sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==}
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
@@ -1264,6 +1273,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@19.2.8:
+    resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
+
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
@@ -1275,6 +1287,11 @@ packages:
     peerDependencies:
       react: '>= 16.3'
       react-dom: '>= 16.3'
+
+  react-test-renderer@19.2.7:
+    resolution: {integrity: sha512-U4TyPDJ9MsC8rFimXuJum8w40aPc9kbOZYO8Pc2/4A884i8hwJsMNA/JNyuOc/f2/37wHvk7HjpVl1V4re7Dig==}
+    peerDependencies:
+      react: ^19.2.7
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -1928,6 +1945,10 @@ snapshots:
       undici-types: 7.24.6
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react-test-renderer@19.1.0':
     dependencies:
       '@types/react': 19.2.17
 
@@ -2791,6 +2812,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@19.2.8: {}
+
   react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       '@types/hast': 3.0.4
@@ -2815,6 +2838,12 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       react-draggable: 4.6.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+
+  react-test-renderer@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-is: 19.2.8
+      scheduler: 0.27.0
 
   react@19.2.7: {}
 

--- a/src/lib/agent-app-command.test.ts
+++ b/src/lib/agent-app-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { AgentAppCommandResponse } from './agent-contract';
+import type { AgentAppCommand, AgentAppCommandResponse } from './agent-contract';
 import {
     AGENT_APP_COMMAND_REQUEST_EVENT,
     AGENT_APP_COMMAND_RESPONSE_EVENT,
@@ -8,6 +8,7 @@ import {
     executeAgentAppCommand,
     parseAgentAppCommandRequest,
     registerAgentAppCommandHost,
+    registerOnboardingAppStateHost,
     requestAgentAppCommand,
     type AgentAppCommandContext,
 } from './agent-app-command';
@@ -18,6 +19,88 @@ import {
     type Profile,
     type Workspace,
 } from './workspace';
+
+describe('read-only App host lifecycle', () => {
+    it('does not execute queued mutations after immediate unregister', async () => {
+        const target = new EventTarget();
+        const { context, workspace } = fixture();
+        const before = structuredClone(workspace());
+        const update = vi.spyOn(context, 'updateWorkspace');
+        const responses = vi.fn();
+        target.addEventListener(AGENT_APP_COMMAND_RESPONSE_EVENT, responses);
+        const stop = registerAgentAppCommandHost(target, context);
+        target.dispatchEvent(new CustomEvent(AGENT_APP_COMMAND_REQUEST_EVENT, {
+            detail: { requestId: 'queued-mutation', command: { name: 'add_panel', args: { type: 'chart' } } },
+        }));
+        stop();
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        expect(update).not.toHaveBeenCalled();
+        expect(workspace()).toEqual(before);
+        expect(responses).not.toHaveBeenCalled();
+    });
+
+    it('does not invoke a queued state reader after immediate unregister', async () => {
+        const target = new EventTarget();
+        const read = vi.fn(() => ({ selectedContract: null, panels: [], layoutPresets: [], layoutProfiles: [] }));
+        const stop = registerAgentAppCommandHost(target, read);
+        target.dispatchEvent(new CustomEvent(AGENT_APP_COMMAND_REQUEST_EVENT, {
+            detail: { requestId: 'queued-read', command: { name: 'get_app_state', args: {} } },
+        }));
+        stop();
+        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        expect(read).not.toHaveBeenCalled();
+    });
+
+    it('requires a real host and serves the unmounted onboarding workspace', async () => {
+        const target = new EventTarget();
+        const query = () => requestAgentAppCommand(target, {
+            requestId: 'boot-state', command: { name: 'get_app_state', args: {} },
+        }, { timeoutMs: 10 });
+        expect((await query()).ok).toBe(false);
+        const stop = registerOnboardingAppStateHost(target);
+        try {
+            expect(await query()).toEqual({
+                requestId: 'boot-state', command: 'get_app_state', ok: true,
+                result: { selectedContract: null, panels: [], layoutPresets: [], layoutProfiles: [] },
+            });
+            expect((await requestAgentAppCommand(target, {
+                requestId: 'boot-mutation', command: { name: 'add_panel', args: { type: 'chart' } },
+            })).ok).toBe(false);
+        } finally { stop(); }
+        expect((await query()).ok).toBe(false);
+    });
+
+    it('reads actual workspace with Harness off but rejects every other command', async () => {
+        const preset = LAYOUT_PRESETS[0];
+        if (!preset) throw new Error('Expected a real layout preset for the mutation test');
+        const { context, resolveContract } = fixture();
+        const target = new EventTarget();
+        const unregister = registerAgentAppCommandHost(target, context, { readOnly: true });
+        try {
+            const response = await requestAgentAppCommand(target, {
+                requestId: 'state', command: { name: 'get_app_state', args: {} },
+            });
+            expect(response).toEqual({ requestId: 'state', command: 'get_app_state', ok: true,
+                result: { selectedContract: { code: '2330', name: '台積電', securityType: 'STK' },
+                    panels: [{ id: 'chart-1', type: 'chart', pin: null }, { id: 'watchlist-1', type: 'watchlist', pin: null }],
+                    layoutPresets: LAYOUT_PRESETS.map(p => p.name), layoutProfiles: ['我的版面'] } });
+            const forbidden: AgentAppCommand[] = [
+                { name: 'list_panels', args: {} },
+                { name: 'select_contract', args: { code: '2317' } },
+                { name: 'add_panel', args: { type: 'chart' } },
+                { name: 'remove_panel', args: { id: 'chart-1' } },
+                { name: 'set_panel_pin', args: { id: 'chart-1', code: '2317' } },
+                { name: 'apply_layout', args: { source: 'preset', name: preset.name } },
+            ];
+            for (const command of forbidden) {
+                expect((await requestAgentAppCommand(target, { requestId: command.name, command })).ok).toBe(false);
+            }
+            expect(resolveContract).not.toHaveBeenCalled();
+            expect(context.getWorkspace().blocks).toHaveLength(2);
+            expect(context.getSelectedContract()?.code).toBe('2330');
+        } finally { unregister(); }
+    });
+});
 
 const contract = (code: string, name = `Name ${code}`): ContractInfo =>
     ({

--- a/src/lib/agent-app-command.ts
+++ b/src/lib/agent-app-command.ts
@@ -474,8 +474,8 @@ function failedResponse(
 
 export function registerAgentAppCommandHost(
     target: EventTarget,
-    context: AgentAppCommandContext,
-    options: { cacheSize?: number } = {},
+    context: AgentAppCommandContext | (() => AgentAppState),
+    options: { cacheSize?: number; readOnly?: boolean } = {},
 ): () => void {
     let active = true;
     const cacheSize = Math.max(1, options.cacheSize ?? 4_096);
@@ -560,7 +560,18 @@ export function registerAgentAppCommandHost(
             return;
         }
 
-        const response = executeAgentAppCommand(request.command, context)
+        const response = Promise.resolve().then(() => {
+            if (!active) {
+                throw new AgentAppCommandError('unsupported', 'App command host is no longer active');
+            }
+            if ((options.readOnly || typeof context === 'function') &&
+                request.command.name !== 'get_app_state') {
+                throw new AgentAppCommandError('unsupported', 'Only read-only App state is available');
+            }
+            return typeof context === 'function'
+                ? context()
+                : executeAgentAppCommand(request.command, context);
+        })
             .then(
                 (result): AgentAppCommandResponse => ({
                     requestId: request.requestId,
@@ -593,6 +604,17 @@ export function registerAgentAppCommandHost(
         active = false;
         target.removeEventListener(AGENT_APP_COMMAND_REQUEST_EVENT, listener);
     };
+}
+
+export function registerOnboardingAppStateHost(target: EventTarget): () => void {
+    // The first-run gate mounts no workspace, selection, or layout controls.
+    // Do not report persisted/default panels as if they were mounted.
+    return registerAgentAppCommandHost(target, () => ({
+        selectedContract: null,
+        panels: [],
+        layoutPresets: [],
+        layoutProfiles: [],
+    }));
 }
 
 export function requestAgentAppCommand<K extends AgentAppCommandName>(


### PR DESCRIPTION
## Scope
Adds only the public App-state helper/tests and React renderer dev dependencies needed by private onboarding tests. Existing App callers, UI behavior and DESKTOP_MODULES_REF remain unchanged.

This independent prerequisite unblocks genuine private desktop-ci against public main before the private-first paired merge of #71. No test skipping or status overriding.

## Verification
Public build/tests and current-private overlay CI must pass before merge. Independent review requested. No release or tag in this PR.