### PR TITLE
feat(debug-panel): 診斷面板「回報問題」按鈕（表單模板可設定，未設定不顯示）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,9 @@ SJ_SEC_KEY=your_secret_key_here
 # Optional: Google Analytics 4. Used only for app_open + app_heartbeat,
 # so GA Realtime can show active users in the last 5/30 minutes.
 # VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+
+# Optional: 「回報問題」button in the 診斷 panel. When set, the button copies
+# a diagnostics block to the clipboard and opens this URL. Placeholders
+# {diag} {ver} {os} {env} {tier} are URL-encoded and substituted, so a
+# Google Forms prefill link works as-is. Unset = button hidden.
+# VITE_FEEDBACK_FORM_URL=https://docs.google.com/forms/d/e/XXXX/viewform?usp=pp_url&entry.AAAA={diag}

--- a/src/components/debug-panel.tsx
+++ b/src/components/debug-panel.tsx
@@ -16,10 +16,18 @@ import { analyticsEnabled } from '../lib/analytics';
 import { useTier } from '../lib/features';
 import type { OrderEventReport } from '../lib/order-report';
 import { appVersion } from '../lib/tauri';
+import { notify } from '../lib/trade';
+import { buildFeedbackUrl, formatDiagnostics } from '../lib/feedback';
 import * as dockStyles from './bottom-dock.css';
+import * as panelStyles from './panel.css';
 import * as styles from './debug-panel.css';
 
 const STATUS_LABEL = { live: 'LIVE', connecting: 'SYNC', down: 'LOST' };
+
+// 「回報問題」表單模板（部署方自設），可含 {diag} {ver} {os} {env} {tier}
+// 占位。未設定時按鈕不渲染，預設不露出任何特定表單。
+const FEEDBACK_FORM_URL =
+    (import.meta.env.VITE_FEEDBACK_FORM_URL as string | undefined) ?? '';
 
 export function DebugPanel() {
     const stream = useStreamStatus();
@@ -112,6 +120,55 @@ export function DebugPanel() {
         },
     ];
 
+    const reportIssue = async () => {
+        // webview 的 navigator.platform 會說謊（Apple Silicon 回 MacIntel），
+        // 跟 server-manager 一樣向 Rust 側拿真實 OS/arch，拿不到再退回
+        let host: string = navigator.platform;
+        try {
+            const { invoke } = await import('@tauri-apps/api/core');
+            host = await invoke<string>('host_info');
+        } catch {
+            // web build 或舊版 shell 沒這個 command
+        }
+        const ctx = {
+            ver,
+            os: host,
+            env: info ? (info.simulation ? 'sim' : 'prod') : 'unknown',
+            tier,
+            stream: STATUS_LABEL[stream],
+            heartbeatAge: hbAge,
+            rate,
+            serverVersion: info ? `v${info.version}` : '',
+            tokenHours:
+                typeof tokenSeconds === 'number'
+                    ? Math.round(tokenSeconds / 3600)
+                    : null,
+            apiBase: getApiBase(),
+        } as const;
+        const diag = formatDiagnostics(ctx);
+        try {
+            await navigator.clipboard.writeText(diag);
+            notify({
+                kind: 'ok',
+                title: '已複製診斷資訊',
+                body: '貼到回報表的「診斷資訊」欄即可',
+            });
+        } catch {
+            notify({
+                kind: 'err',
+                title: '複製失敗',
+                body: '請手動截圖面板內容',
+            });
+        }
+        const url = buildFeedbackUrl(FEEDBACK_FORM_URL, ctx, diag);
+        try {
+            const { open } = await import('@tauri-apps/plugin-shell');
+            await open(url);
+        } catch {
+            window.open(url, '_blank', 'noopener');
+        }
+    };
+
     return (
         <div className={styles.wrap}>
             <div className={styles.grid}>
@@ -126,6 +183,15 @@ export function DebugPanel() {
                     </div>
                 ))}
             </div>
+            {FEEDBACK_FORM_URL && (
+                <button
+                    type="button"
+                    className={panelStyles.btn}
+                    onClick={() => void reportIssue()}
+                >
+                    回報問題
+                </button>
+            )}
             <span className={styles.sectionTitle}>最近 order_event</span>
             {events.length === 0 && (
                 <span className={dockStyles.emptyState}>尚無事件</span>

--- a/src/lib/feedback.test.ts
+++ b/src/lib/feedback.test.ts
@@ -1,0 +1,71 @@
+// src/lib/feedback.test.ts — 回報問題按鈕的純邏輯：占位符要 URL-encode、
+// 沒占位符原樣回傳、未知值不能漏出 "null"/"undefined"、第一行格式與
+// server-manager 的「複製診斷資訊」一致。
+
+import { describe, expect, it } from 'vitest';
+import {
+    buildFeedbackUrl,
+    formatDiagnostics,
+    type FeedbackContext,
+} from './feedback';
+
+const ctx: FeedbackContext = {
+    ver: '0.1.39',
+    os: 'Windows x64',
+    env: 'sim',
+    tier: 'free',
+    stream: 'LIVE',
+    heartbeatAge: 3,
+    rate: '12.4',
+    serverVersion: 'v1.7.1',
+    tokenHours: 11,
+    apiBase: '',
+};
+
+describe('formatDiagnostics', () => {
+    it('first line matches the server-manager copy format', () => {
+        const [first] = formatDiagnostics(ctx).split('\n');
+        expect(first).toBe('Shioaji Pro v0.1.39 · Windows x64');
+    });
+
+    it('renders unknowns as placeholders, never "null"/"undefined"', () => {
+        const out = formatDiagnostics({
+            ...ctx,
+            ver: '',
+            heartbeatAge: null,
+            serverVersion: '',
+            tokenHours: null,
+            env: 'unknown',
+        });
+        expect(out).toContain('Shioaji Pro v?');
+        expect(out).toContain('heartbeat: —');
+        expect(out).toContain('server: — (unknown)');
+        expect(out).toContain('token: —');
+        expect(out).toContain('api: (same-origin)');
+        expect(out).not.toMatch(/null|undefined/);
+    });
+});
+
+describe('buildFeedbackUrl', () => {
+    it('substitutes and URL-encodes every placeholder', () => {
+        const url = buildFeedbackUrl(
+            'https://f/x?ver={ver}&os={os}&env={env}&tier={tier}&d={diag}',
+            ctx,
+            'line1\nline 2 & more',
+        );
+        expect(url).toBe(
+            'https://f/x?ver=0.1.39&os=Windows%20x64&env=sim&tier=free&d=line1%0Aline%202%20%26%20more',
+        );
+    });
+
+    it('returns the template unchanged when it has no placeholders', () => {
+        const t = 'https://docs.google.com/forms/d/e/abc/viewform';
+        expect(buildFeedbackUrl(t, ctx, 'ignored')).toBe(t);
+    });
+
+    it('leaves unknown braces alone', () => {
+        expect(buildFeedbackUrl('https://f/?x={nope}', ctx, '')).toBe(
+            'https://f/?x={nope}',
+        );
+    });
+});

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,0 +1,52 @@
+// src/lib/feedback.ts — 診斷面板「回報問題」：組診斷區塊、套表單 URL 模板。
+// 純函式，不碰 DOM / Tauri，讓 debug-panel 只剩黏合層，也方便測試。
+//
+// 設計取捨：不自動送出任何資料。按鈕只做「複製診斷 + 開表單」，使用者到
+// 表單後自己決定貼什麼。零後端、不碰截圖隱私、開源版不用塞永豐專用端點。
+
+export interface FeedbackContext {
+    ver: string; // app version，未知為 ''
+    os: string; // host_info 或 navigator.platform
+    env: 'sim' | 'prod' | 'unknown';
+    tier: string;
+    stream: string; // LIVE / SYNC / LOST
+    heartbeatAge: number | null; // 秒
+    rate: string; // 筆/秒
+    serverVersion: string; // 'v1.7.1'，未知為 ''
+    tokenHours: number | null;
+    apiBase: string; // '' 代表同源
+}
+
+/** 三行診斷區塊。第一行與 server-manager 的「複製診斷資訊」同格式，上游一眼認得。 */
+export function formatDiagnostics(c: FeedbackContext): string {
+    const hb = c.heartbeatAge === null ? '—' : `${c.heartbeatAge}s ago`;
+    const token = c.tokenHours === null ? '—' : `${c.tokenHours}h`;
+    return [
+        `Shioaji Pro v${c.ver || '?'} · ${c.os}`,
+        `tier: ${c.tier} · stream: ${c.stream} · heartbeat: ${hb} · rate: ${c.rate}/s`,
+        `server: ${c.serverVersion || '—'} (${c.env}) · token: ${token} · api: ${c.apiBase || '(same-origin)'}`,
+    ].join('\n');
+}
+
+const PLACEHOLDER = /\{(diag|ver|os|env|tier)\}/g;
+
+/**
+ * 把模板裡的 {diag} {ver} {os} {env} {tier} 換成 URL-encoded 值。
+ * 沒有占位符就原樣回傳，所以任何表單平台的連結都能直接當模板。
+ */
+export function buildFeedbackUrl(
+    template: string,
+    c: FeedbackContext,
+    diag: string,
+): string {
+    const vars: Record<string, string> = {
+        diag,
+        ver: c.ver,
+        os: c.os,
+        env: c.env,
+        tier: c.tier,
+    };
+    return template.replace(PLACEHOLDER, (_, key: string) =>
+        encodeURIComponent(vars[key] ?? ''),
+    );
+}


### PR DESCRIPTION
診斷面板已經匯集了回報問題最需要的全部資訊（版本、stream 狀態、心跳、行情速率、server 版本、token 效期），但使用者要回報時得自己抄。這顆按鈕把「收集」到「送達」的最後一哩接起來，也把 #23/#24/#28 那幾輪回報時「請使用者附診斷資訊」的動作變成一鍵。

## 行為

- 按下「回報問題」：複製三行診斷區塊到剪貼簿（第一行與伺服器面板「複製診斷資訊」同格式）→ 開啟部署方設定的表單連結。
- `VITE_FEEDBACK_FORM_URL` 未設定時**按鈕完全不渲染**，開源版預設不露出任何特定表單。
- 模板支援 `{diag}` `{ver}` `{os}` `{env}` `{tier}` 占位符（自動 URL-encode），Google Forms 預填連結可直接當模板；無占位符的連結原樣開啟。

## 設計取捨

- **不自動送出任何資料**：只做「複製＋開表單」，使用者到表單後自己決定貼什麼。零後端、不碰截圖與隱私。
- OS 資訊與 server-manager 同路：優先 Rust 側 `host_info`（webview 的 navigator.platform 會謊報 Apple Silicon），拿不到退回 navigator.platform。
- 開連結優先 `@tauri-apps/plugin-shell`（既有依賴，tauri.ts 同模式），web build 退回 `window.open`。

## 驗證

- `tsc -b` 乾淨、`vitest run` 186/186（新增 src/lib/feedback.test.ts 判定表：占位符 URL-encode、無占位符原樣回傳、未知值不得漏出 null/undefined、診斷首行與複製診斷資訊格式對齊）、`vite build` 通過（依 docs/DEV.md 的 CI 三件組在本地先跑過）。
- UI 為純加法：一顆按鈕，未設定環境變數時與現版完全相同。

🤖 Generated with [Claude Code](https://claude.com/claude-code)