### PR TITLE
fix(ci): 避免合成測試重複觸發與互相取消

### DIFF
--- a/.github/workflows/desktop-agent-ci.yml
+++ b/.github/workflows/desktop-agent-ci.yml
@@ -7,12 +7,11 @@ on:
   push:
     branches:
       - main
-      - 'codex/**'
-      - 'feat/**'
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  # PR updates replace older runs of that PR; manual runs cannot cancel PR checks.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -84,6 +84,18 @@ test coverage 門檻、quality metrics 等。落地時更新本節。
 - 私有 repo 的 PR 會透過 `repository_dispatch` 觸發本 repo 的
   `desktop-ci.yml` 做合成驗證（詳見私有 repo 的 DEV.md）。
 
+### Desktop Agent CI 觸發與驗收
+
+- `desktop-agent-ci.yml` 在指向 main 的 PR 開啟／更新時跑 Linux/Windows
+  合成測試；push 只監聽 main，避免開發分支同一個 commit 同時觸發 push
+  與 PR 兩輪，互相取消後在 PR 留下紅叉。
+- 尚未開 PR 的分支若要合成驗證，使用 `workflow_dispatch` 手動選擇分支。
+- concurrency 依 workflow、事件與 PR 編號／ref 分組。新 commit 可取消
+  同 PR 的舊 run，但手動執行、main push 與其他 PR 不互相取消。
+- 回報 CI 完成前，核對最新 PR head 的完整 check rollup；若仍有 failed、
+  cancelled 或 pending，不得只挑成功的 run 宣告全綠。取消原因與重跑結果
+  須寫回 PR，等待所有檢查完成後再交付。
+
 ### 公私 paired PR 的 merge 順序
 
 同一功能同時修改 public/private 時，兩個 PR 必須先以


### PR DESCRIPTION
開發分支同一個 commit 同時觸發 push 與 pull_request 合成 CI，兩輪共用 concurrency group，後啟動的一輪取消另一輪，導致 PR #83 留下紅叉 4/6。#83 已於全部六项成功後用 merge commit 合併，本 PR 修正觸發根因。

`desktop-agent-ci` 的 push 只保留 main；開發分支透過指向 main 的 PR 自動驗證，未開 PR 可用 workflow_dispatch。Concurrency 依 workflow、事件及 PR 編號／ref 分組，保留同 PR 更新取消舊 run，但不同 PR、手動與 main push 不互相取消。Linux／Windows 矩陣、測試步驟、private pin 均未變。

docs/DEV.md 記錄觸發方式，並要求確認最新 head 的完整 check rollup，不能只挑成功 run 宣告全綠。

## 驗證

- 獨立 code review PASS，無 confirmed finding。
- 獨立 QA：Ruby YAML 解析、事件矩陣斷言、concurrency 情境代入、git diff --check 全部 PASS。
- GitHub 事件實測：新分支 push 後無 workflow run；PR 建立後只有三個 pull_request workflow（required、web、desktop-agent），無 push run。Head `a003853a453f6095ffef0c1abb455dcc559efe55` 的完整 check rollup **4/4 SUCCESS**，沒有 cancelled、failure 或 pending。
- [required CI](https://github.com/Sinotrade/shioaji-pro-app/actions/runs/34696241937)、[web build](https://github.com/Sinotrade/shioaji-pro-app/actions/runs/34696241929)、[Linux／Windows composite](https://github.com/Sinotrade/shioaji-pro-app/actions/runs/34696241950) 均完整成功。
- #83 merge commit `f9a36abcba6732c331e5b0194c8edbc602bcdb0f` 的 main CI 也已成功：[真正 Desktop CI](https://github.com/Sinotrade/shioaji-pro-app/actions/runs/34696132187)、[Linux／Windows composite](https://github.com/Sinotrade/shioaji-pro-app/actions/runs/34696132213)、web build 與 Pages。
- 未修改 App/runtime，不需新的原生登入或交易測試；沒有下單。手動 dispatch、跨 fork PR 與快速連續更新的取消行為僅靜態驗證，沒有實際觸發。

此 PR 已依使用者明確授權，以 merge commit `95bff4a1135f7ab134de898aed3243b6ebb9485d` 合併。主 checkout 已 fast-forward 且乾淨；本 PR worktree 與本地分支已清理。沒有 tag／發布。合併後 main CI 已觸發，尚在執行，不能將合併前 4/4 結果當成合併後驗證。
